### PR TITLE
tuning-geofeeds: restore canonical MCP origin

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -2,7 +2,7 @@
   "servers": {
     "fastah-netops": {
       "type": "http",
-      "url": "https://mcp.global.fastah.ai/mcp"
+      "url": "https://mcp.fastah.ai/mcp"
     }
   }
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Prepare one reviewable pull request against `https://github.com/fastah/ip-geofee
 
 1. Replace the public working tree with the generated stage and record its private source commit.
 2. Replace the active `geofeed-tuner` discovery entries with `tuning-geofeeds`.
-3. Remove every legacy file absent from the generated stage, including `skills/geofeed-tuner/`, `experimental/ip-geofeed/`, `README-PLUGIN.md`, the stale `.github/skills` link, old setup files, and metadata that points to `mcp.fastah.ai`.
+3. Remove every legacy file absent from the generated stage, including `skills/geofeed-tuner/`, `experimental/ip-geofeed/`, `README-PLUGIN.md`, the stale `.github/skills` link, old setup files, and metadata that points to `mcp.global.fastah.ai`.
 4. Keep public history through Git rather than shipping two active skills.
 5. Exclude feeds other than allowlisted eval fixtures, runtime captures, benchmark transcripts, private validation, credentials, local paths, and generated work directories.
 6. Verify every staged file against `public-export-manifest.json` before merge.

--- a/README.md
+++ b/README.md
@@ -174,6 +174,6 @@ These versions move independently. Include them with the source digest when you 
 - Website: [https://getfastah.com/](https://getfastah.com/)
 - Support: [support@getfastah.com](mailto:support@getfastah.com)
 - [Privacy policy](https://www.iubenda.com/privacy-policy/40053234)
-- [Terms of use](https://mcp.global.fastah.ai/terms-of-use.txt)
+- [Terms of use](https://mcp.fastah.ai/terms-of-use.txt)
 - [Maintainer and release instructions](CONTRIBUTING.md)
 - [Migration from `geofeed-tuner`](MIGRATION.md)

--- a/marketplace-metadata.json
+++ b/marketplace-metadata.json
@@ -98,7 +98,7 @@
     "llmsTxtLinked": true,
     "source": "gen2/cmd/worker-mcp/terms-of-use.txt"
   },
-  "termsOfServiceUrl": "https://mcp.global.fastah.ai/terms-of-use.txt",
-  "termsUrlStatus": "live-inconsistent-load-balanced-body-head-200-recheck-inconclusive",
+  "termsOfServiceUrl": "https://mcp.fastah.ai/terms-of-use.txt",
+  "termsUrlStatus": "canonical-origin-verification-required-historical-global-evidence-retained",
   "website": "https://getfastah.com/"
 }

--- a/mcp-plugin.json
+++ b/mcp-plugin.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "fastah-netops": {
       "type": "http",
-      "url": "https://mcp.global.fastah.ai/mcp"
+      "url": "https://mcp.fastah.ai/mcp"
     }
   }
 }

--- a/public-export-manifest.json
+++ b/public-export-manifest.json
@@ -278,9 +278,9 @@
       "source": "tests/test_mcp_exchange.py"
     },
     {
-      "bytes": 5360,
+      "bytes": 5370,
       "path": "tuning-geofeeds/package/tests/test_public_packaging.py",
-      "sha256": "8ad7476d63452a42d2e2b10bcc43a62fdfea730c8666af50a98e17e60c88dbcd",
+      "sha256": "ba8563749c7c0b275ee7bbb69672f9af513ec67efcc892189774392015a64f14",
       "source": "tests/test_public_packaging.py"
     },
     {
@@ -369,7 +369,7 @@
     ]
   },
   "skill": "tuning-geofeeds",
-  "source_commit": "0474fabc1720a850753997fe78d137f534519487",
+  "source_commit": "846cd45574be3f87f897c4ce1e7bc59edf883e03",
   "stagingFiles": [
     {
       "bytes": 495,
@@ -378,15 +378,15 @@
       "source": "tuning-geofeeds/packaging/release.json+tuning-geofeeds/packaging/openai-submission.json"
     },
     {
-      "bytes": 122,
+      "bytes": 115,
       "path": ".vscode/mcp.json",
-      "sha256": "79475b14a1e58de86c70adf10d6803ce223e1304c96e2c40dcf6f651c0cb6f98",
+      "sha256": "dd18e553fff186abc979c1c83dcb6432fec9596c2e882f5b265397162569e7d5",
       "source": "tuning-geofeeds/packaging/release.json"
     },
     {
-      "bytes": 3445,
+      "bytes": 3452,
       "path": "CONTRIBUTING.md",
-      "sha256": "cf27530773fe1a301712b7177a724de4f5d0387aa6717b86122a765311c19892",
+      "sha256": "3bbb7a46bd35012a52f8417cac4a47a4e5cb1edd53e611bdea21ce75ce0b2eb3",
       "source": "tuning-geofeeds/packaging/public-root/CONTRIBUTING.md+tuning-geofeeds/packaging/release.json+pyproject.toml+schema/analysis.schema.json"
     },
     {
@@ -402,21 +402,21 @@
       "source": "tuning-geofeeds/packaging/public-root/MIGRATION.md+tuning-geofeeds/packaging/release.json+pyproject.toml+schema/analysis.schema.json"
     },
     {
-      "bytes": 12857,
+      "bytes": 12850,
       "path": "README.md",
-      "sha256": "a1c88e9a4f77ee4eb5a57f71dd41f1e08e67f9fc57ab4ef26f2e5027b1f795ff",
+      "sha256": "a6ea248efbb900656e11040eb9aa4dfab5a4f155e5b9727da6f9a029da5a10b8",
       "source": "tuning-geofeeds/packaging/public-root/README.md+tuning-geofeeds/packaging/release.json+pyproject.toml+schema/analysis.schema.json"
     },
     {
-      "bytes": 3582,
+      "bytes": 3583,
       "path": "marketplace-metadata.json",
-      "sha256": "066d52c71b679d9858921b00b3caeffb216e15c7ee15650e9dd71f0db0aff68f",
+      "sha256": "8381797501cc59ad2efaed73c7dc398dbcc13acefc51d67082307d7ae5e778c6",
       "source": "tuning-geofeeds/packaging/release.json"
     },
     {
-      "bytes": 125,
+      "bytes": 118,
       "path": "mcp-plugin.json",
-      "sha256": "b35b727b4bdbe7f5a44dba473a1443ce90be77327436178bdad6074b49def41b",
+      "sha256": "514db5ca43ed864cf5d92bbac9fb1612099d3a06c40e95d6990cab77558f8150",
       "source": "tuning-geofeeds/packaging/release.json"
     }
   ],

--- a/tuning-geofeeds/package/tests/test_public_packaging.py
+++ b/tuning-geofeeds/package/tests/test_public_packaging.py
@@ -86,7 +86,7 @@ def test_public_root_is_generated_from_canonical_metadata(tmp_path: Path) -> Non
         "`do_not_geolocate`",
         "around 225 MB",
         "remarks: Geofeed https://...",
-        "https://mcp.global.fastah.ai/terms-of-use.txt",
+        "https://mcp.fastah.ai/terms-of-use.txt",
     ):
         assert text in readme
     assert "{{" not in readme
@@ -113,14 +113,14 @@ def test_public_root_is_generated_from_canonical_metadata(tmp_path: Path) -> Non
         )
     )
     assert "geofeed-tuner" not in discovery
-    assert "https://mcp.fastah.ai/mcp" not in discovery
-    assert "https://mcp.global.fastah.ai/mcp" in discovery
+    assert "https://mcp.global.fastah.ai/mcp" not in discovery
+    assert "https://mcp.fastah.ai/mcp" in discovery
 
 
-def test_public_root_rejects_stale_mcp_discovery(tmp_path: Path) -> None:
+def test_public_root_rejects_outdated_global_mcp_discovery(tmp_path: Path) -> None:
     packager = _packager()
     config = deepcopy(_config())
-    config["mcp"]["url"] = "https://mcp.fastah.ai/mcp"
+    config["mcp"]["url"] = "https://mcp.global.fastah.ai/mcp"
 
     with pytest.raises(ValueError, match="legacy active skill or endpoint"):
         packager._stage_public_root(tmp_path, config)


### PR DESCRIPTION
## Summary
- restore `https://mcp.fastah.ai/mcp` as the public Fastah MCP endpoint
- restore `https://mcp.fastah.ai/terms-of-use.txt` as the active Terms URL
- retain the former global origin only as clearly labeled historical evidence and negative regression coverage
- refresh the generated public manifest from private monorepo source `846cd45574be3f87f897c4ce1e7bc59edf883e03`

## Verification
- canonical `skill-public-stage` generation passed under Python 3.14.7
- public tree matches all 67 generated files byte-for-byte
- manifest inventory and hashes passed
- active global MCP URL matches: 0
- secrets, private paths, runtime captures, and `.egg-info` checks passed
- generated manifest SHA-256: `8d3b4d13afe081d9dda1d0cda9be3e4060b783f0fb288e97c3aee006c8f06c7d`
- `publicationPerformed=false`

This PR updates repository metadata only. It does not establish live Terms, OAuth, or domain verification and does not publish to a marketplace.