### PR TITLE
tuning-geofeeds: publish Claude field feedback updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,21 +36,20 @@ tuning-geofeeds/
 
 Product identity, plugin version, MCP endpoint and contract, publisher, support, privacy, and Terms values come from `tuning-geofeeds/packaging/release.json`. Python and analyzer versions come from `gen2/geofeed-quality/pyproject.toml`. Analysis schema version comes from the committed schema. Public prose comes from `tuning-geofeeds/packaging/public-root/`. The public Apache-2.0 license comes from `tuning-geofeeds/packaging/public/LICENSE`.
 
-## Public migration pull request
+## Public update pull request
 
 Prepare one reviewable pull request against `https://github.com/fastah/ip-geofeed-skills`. It should:
 
 1. Replace the public working tree with the generated stage and record its private source commit.
-2. Replace the active `geofeed-tuner` discovery entries with `tuning-geofeeds`.
-3. Remove every legacy file absent from the generated stage, including `skills/geofeed-tuner/`, `experimental/ip-geofeed/`, `README-PLUGIN.md`, the stale `.github/skills` link, old setup files, and metadata that points to `mcp.global.fastah.ai`.
-4. Keep public history through Git rather than shipping two active skills.
-5. Exclude feeds other than allowlisted eval fixtures, runtime captures, benchmark transcripts, private validation, credentials, local paths, and generated work directories.
-6. Verify every staged file against `public-export-manifest.json` before merge.
+2. Confirm `geofeed-tuner` and its legacy discovery metadata have not returned.
+3. Remove files absent from the generated stage rather than carrying stale copies.
+4. Exclude feeds other than allowlisted eval fixtures, runtime captures, benchmark transcripts, private validation, credentials, local paths, and generated work directories.
+5. Verify every staged file against `public-export-manifest.json` before merge.
 
 The migration is not a compatibility release. Reanalyze original source feeds with `tuning-geofeeds`; do not import legacy reports as current Analysis JSON.
 
 ## Readiness
 
-Public and marketplace release remain blocked under the current private release policy. Open items include product-owned secure acquisition, measured 60,000-row time/memory/browser budgets, production Terms and OAuth consistency, deployed log-retention evidence, clean host verification, and marketplace review. A local-file-first preview would require an explicit product decision changing those gates. Generating this tree does not make that decision.
+The local-file-first GitHub Skill is public, and its isolated Amp install has been smoke-tested. Marketplace release remains blocked by product-owned secure acquisition, measured 60,000-row time/memory/browser budgets, live production Terms and OAuth consistency, deployed log-retention evidence, clean Claude and OpenAI host verification, reviewer access, and marketplace review. An allowlisted host asking the user to upload the CSV is supported behavior; it is not permission to bypass network policy.
 
-Sequence shared-state work separately: merge the private implementation, generate and review the public pull request, publish to public GitHub with approval, smoke-test the public Amp install, validate Claude and OpenAI hosts, close production blockers, then submit marketplaces with separate approval.
+Sequence shared-state work separately: merge the private implementation, generate and review the public pull request, publish to public GitHub with approval, repeat the public Amp install smoke, validate Claude and OpenAI hosts, close production and product blockers, then submit marketplaces last with separate approval.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,14 +2,14 @@
 
 `tuning-geofeeds` supersedes the legacy `geofeed-tuner` skill.
 
-The future public migration pull request will remove the legacy skill, experimental implementation, and stale discovery metadata. The two skills will not be listed as active alternatives.
+The public migration removed the legacy skill, experimental implementation, and stale discovery metadata. The two skills are not listed as active alternatives.
 
 The current skill uses a versioned Analysis JSON contract, keeps authored rows and physical lines, separates findings from evidence, limits online data, and requires exact proposal approvals before writing a corrected feed. Legacy reports and generated files do not satisfy this contract.
 
 To migrate:
 
 1. Keep the original geofeed CSV.
-2. Install `tuning-geofeeds` from the migrated public repository.
+2. Install `tuning-geofeeds` from the public repository.
 3. Analyze the original CSV again.
 4. Review new findings and proposals on their own evidence.
 5. Approve exact proposal IDs only after review.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Fastah NetOps Tools helps you check a public IP geofeed, decide what to fix, rec
 
 The `tuning-geofeeds` skill works with [RFC 8805](https://www.rfc-editor.org/rfc/rfc8805.html) CSV feeds. It keeps your source file unchanged. It explains what needs attention and creates proposals when you ask. You choose every change. It never silently overwrites or publishes a feed.
 
+## Get the feed
+
+Claude Cowork, other cloud agents, and corporate networks may block some HTTPS downloads. If the host cannot fetch your feed URL, upload the CSV. This is the intended path. Do not ask the agent to bypass the host's network policy or reconstruct rows.
+
 ## What it does not do
 
 - It does not manage private IP address plans.
@@ -17,7 +21,7 @@ The `tuning-geofeeds` skill works with [RFC 8805](https://www.rfc-editor.org/rfc
 |---|---|
 | Python | 3.14 or newer |
 | Input | A local, strict UTF-8 RFC 8805 CSV file |
-| Amp | Install from this public repository after publication |
+| Amp | Published from this public repository; the complete repository install has passed an isolated Amp smoke test |
 | Claude and OpenAI marketplaces | Not published yet. Do not treat generated review packages as listings. |
 | Internet access | Not needed for the standard offline report |
 | Optional online checks | Direct registry checks and Fastah place search, only after you agree |
@@ -28,7 +32,7 @@ Install the complete skill in Amp:
 amp skill add --overwrite https://github.com/fastah/ip-geofeed-skills.git
 ```
 
-Then ask Amp to use `tuning-geofeeds`, or start with the first prompt below. The packaged repository layout is checked with a real isolated Amp installation before release.
+Then ask Amp to use `tuning-geofeeds`, or start with the first prompt below. The packaged repository layout is checked with a real isolated Amp installation.
 
 ## Check a local feed in five minutes
 
@@ -40,7 +44,7 @@ Attach or name the local file, then ask:
 
 > Analyze `/path/to/geofeed.csv` as a public RFC 8805 geofeed. Keep the source unchanged. Work offline. Create Analysis JSON, a Markdown summary, an offline HTML dashboard, and GeoJSON.
 
-Start with Markdown for a quick review. Open the HTML dashboard when you need row filters and linked evidence. Keep the Analysis JSON: it is the complete, machine-readable record used to create every report.
+Start with Markdown for a quick review. Open the HTML dashboard when you need row filters and linked evidence. Keep the Analysis JSON: it is the complete, machine-readable record used to create every report. Its `source.sha256` value supports audits and binds later approvals to the analyzed file. You do not normally need to calculate another digest.
 
 ### 2. Understand what needs attention
 
@@ -103,7 +107,7 @@ All local artifacts stay in the work directory you choose until you delete or sh
 | Analysis JSON | Complete typed record of rows, findings, relationships, and optional evidence | Local. It can contain prefixes, source values, and retained physical lines. |
 | Markdown | Fast review and change discussion | Local unless you share it. It can name prefixes and findings. |
 | Offline HTML | Searchable dashboard with the Analysis data embedded | Local unless you share it. It contains the full report and can be large. |
-| GeoJSON | Map data from existing place evidence | Local unless you share it. It contains canonical prefixes and advisory locations. |
+| GeoJSON | Map data from MCP place evidence | Local unless you share it. Offline or registry-only analysis produces a valid empty FeatureCollection and an informational CLI message; no geometry is invented. |
 | Correction plan and approval | Exact proposals and your decisions | Local. They bind decisions to the source and analysis. |
 | Corrected CSV | Full approved feed for your publication process | Local until you publish it. Publication is always manual. |
 | Registry request | Optional authority-consistency check | The canonical prefix goes directly to the authoritative registry selected through current bootstrap data. |
@@ -140,8 +144,9 @@ Fastah MCP service logs are separate from your local artifacts. The release poli
 |---|---|---|
 | Up to 60,000 data rows | The complete feed can be analyzed. Comments and blank lines do not count. | Keep the complete source and review the output sizes. |
 | More than 60,000 data rows | Analysis stops before creating partial Analysis JSON. Nothing is truncated. | Do not split the feed to hide the limit. Reduce scope only through your normal source-management process. |
-| Invalid UTF-8 | Local analysis stops with an encoding error. | Keep the original bytes. Save a separate verified UTF-8 working copy with provenance. |
-| Remote feed URL | Download is owned by the host, not this package. | Save the feed locally with a controlled HTTPS downloader. Keep the original response bytes and retrieval details. |
+| Invalid UTF-8 | Local analysis stops with an encoding error. | Keep the original file. Save a separate verified UTF-8 working copy. |
+| Remote feed URL | Download is owned by the host, not this package. Allowlisted networks may block it. | Use the host's normal download capability. If unavailable, upload the CSV. Do not bypass network policy or reconstruct it. |
+| Empty GeoJSON | The valid FeatureCollection has no features when no MCP place evidence supplies usable coordinates or bounds. | Use Markdown and Analysis JSON for offline findings. Run optional MCP only after agreeing to its privacy boundary. RDAP does not populate GeoJSON. |
 | Declared non-UTF-8 source | The analyzer does not silently convert it. | For a response such as `Content-Type: text/csv; charset=ISO-8859-1`, keep the raw file and create a separate strict UTF-8 copy with both digests. LACNIC has been observed using this pattern; do not special-case a hostname. |
 | Prefix has host bits | The authored CIDR is retained but marked invalid. | Confirm the intended network address. Do not accept automatic masking without checking the allocation. |
 | Country or region code is invalid | The row is retained with a finding. | Check the intended ISO country and subdivision code. Empty or `ZZ` country has a separate do-not-geolocate meaning. |

--- a/public-export-manifest.json
+++ b/public-export-manifest.json
@@ -2,9 +2,9 @@
   "bundle": "fastah-netops-tools-agent-skills",
   "files": [
     {
-      "bytes": 9829,
+      "bytes": 9920,
       "path": "tuning-geofeeds/SKILL.md",
-      "sha256": "ee45265480277765f70f607e8a2341bfc00e1ae78c758d19201920817de94522",
+      "sha256": "65f4e159c57ce0a8f86d69a432c2a01c33eee427605241057656d5e65c810f14",
       "source": "tuning-geofeeds/SKILL.md"
     },
     {
@@ -14,9 +14,9 @@
       "source": "tuning-geofeeds/evals/README.md"
     },
     {
-      "bytes": 10279,
+      "bytes": 10357,
       "path": "tuning-geofeeds/evals/evals.json",
-      "sha256": "3e4cb90ef094c0bac9eda6d6a309606d6e66a12f29d217557b45ecaf1e1bb659",
+      "sha256": "320fee13fc8da7b6a977c8b79e9ab2a1e114b537c7c025bb4cdc8aa6da501ccc",
       "source": "tuning-geofeeds/evals/evals.json"
     },
     {
@@ -92,15 +92,15 @@
       "source": "tuning-geofeeds/evals/trigger-queries.json"
     },
     {
-      "bytes": 5072,
+      "bytes": 5194,
       "path": "tuning-geofeeds/package/Makefile",
-      "sha256": "2807a1cefa52a7cc639901a5c51063058460349f979fe1cc3e420e8ec27b4724",
+      "sha256": "d2bd60abb8021ecd1f4e29df990505f65600514aa8de25e130c812e27a5fdc4e",
       "source": "Makefile"
     },
     {
-      "bytes": 1143,
+      "bytes": 1823,
       "path": "tuning-geofeeds/package/README.md",
-      "sha256": "be468db8c25bb9422d7ca2ec22a233e55f6d917161f2703ef323509e2dd9cccb",
+      "sha256": "fa6752d4f166d5e8e49c60117536ec31889649e4f104e05df8f8cdf7bccb1b29",
       "source": "tuning-geofeeds/assets/package-README.md"
     },
     {
@@ -158,9 +158,9 @@
       "source": "schema/mcp-request-mapping.schema.json"
     },
     {
-      "bytes": 723,
+      "bytes": 799,
       "path": "tuning-geofeeds/package/src/geofeed_quality/__init__.py",
-      "sha256": "ad0e99ea861997c1f86ba6ee428b54252ded94ae8cbac967dd0418b5616135f3",
+      "sha256": "75ace06b3239549efa928d2bb95a386ccf22a173aca959c2131b7b96c23a6547",
       "source": "src/geofeed_quality/__init__.py"
     },
     {
@@ -170,9 +170,9 @@
       "source": "src/geofeed_quality/analyzer.py"
     },
     {
-      "bytes": 14708,
+      "bytes": 14984,
       "path": "tuning-geofeeds/package/src/geofeed_quality/cli.py",
-      "sha256": "0c30b832c946d2624e0c5a89429801a66e22bf27f281e4b3d795719cae686a6b",
+      "sha256": "b03062d13870669a24791f96606abcb34e71be1a5dcaa75412f13d6a96e61c23",
       "source": "src/geofeed_quality/cli.py"
     },
     {
@@ -224,9 +224,9 @@
       "source": "src/geofeed_quality/renderer.py"
     },
     {
-      "bytes": 472,
+      "bytes": 876,
       "path": "tuning-geofeeds/package/src/geofeed_quality/runtime.py",
-      "sha256": "bf02967c5220eb6a5ca766d00b4a65f2a9e040d42a687b5c91110b636405273a",
+      "sha256": "4db3042d12a8057e7ff0095d9f9e143dd26d5952e86a1a5d4f093048e7164439",
       "source": "src/geofeed_quality/runtime.py"
     },
     {
@@ -260,9 +260,9 @@
       "source": "tests/test_analyzer.py"
     },
     {
-      "bytes": 10189,
+      "bytes": 10712,
       "path": "tuning-geofeeds/package/tests/test_cli.py",
-      "sha256": "d38fd99d84da265a296779a11781b3f637bbbc549fb60e77e4073c94655fe3c8",
+      "sha256": "ba060341b52c393290456640f045a6d37db2d0162a1271c4cb7afe630bb629e9",
       "source": "tests/test_cli.py"
     },
     {
@@ -278,9 +278,9 @@
       "source": "tests/test_mcp_exchange.py"
     },
     {
-      "bytes": 5370,
+      "bytes": 5606,
       "path": "tuning-geofeeds/package/tests/test_public_packaging.py",
-      "sha256": "ba8563749c7c0b275ee7bbb69672f9af513ec67efcc892189774392015a64f14",
+      "sha256": "1ca5fc7df012a9b8cc761558625a8756d95e16cbb95680531a853cc7d7bf2ed1",
       "source": "tests/test_public_packaging.py"
     },
     {
@@ -296,9 +296,9 @@
       "source": "tests/test_rdap.py"
     },
     {
-      "bytes": 1893,
+      "bytes": 3592,
       "path": "tuning-geofeeds/package/tests/test_runtime.py",
-      "sha256": "21aed029973330d2506db4fee4b3ac6c65cd1ef1a3d039aedd1dcd9eea55eeec",
+      "sha256": "7d63eb901bccabd2afb1834b2bb5ba141680cadc65fc94cdbb5d26893d1bb520",
       "source": "tests/test_runtime.py"
     },
     {
@@ -320,21 +320,21 @@
       "source": "tuning-geofeeds/references/interpretation.md"
     },
     {
-      "bytes": 2503,
+      "bytes": 4073,
       "path": "tuning-geofeeds/references/setup.md",
-      "sha256": "a3b3363ba8cb5b6c9833dff40baaebc7a80e17ea957104e87dbc34c56675b8a5",
+      "sha256": "08d7885812af2a6f33c2903cb7dc0ac276f61976445816e4a0a7a107f66c13f1",
       "source": "tuning-geofeeds/references/setup.md"
     },
     {
-      "bytes": 19283,
+      "bytes": 19511,
       "path": "tuning-geofeeds/scripts/evaluate.py",
-      "sha256": "673dba48c2eb10799d2425f5e552e41243a4ed9fc2ad0e83ed8b348ac222501c",
+      "sha256": "44d3bafdc508a4646699c42d5bfd1bc4953acd73fa76c4feb14b51873f09ed74",
       "source": "tuning-geofeeds/scripts/evaluate.py"
     },
     {
-      "bytes": 1566,
+      "bytes": 1793,
       "path": "tuning-geofeeds/scripts/geofeed_cli.py",
-      "sha256": "a13d831ab5ff2603ee6af2154555fb39a9d8875f2a76ad4a933aa94a3cfd56fc",
+      "sha256": "14df943a34b34c98d49935ece8a94a8d771644de4f70c9a393ee89f64d77a3ec",
       "source": "tuning-geofeeds/scripts/geofeed_cli.py"
     },
     {
@@ -369,7 +369,7 @@
     ]
   },
   "skill": "tuning-geofeeds",
-  "source_commit": "846cd45574be3f87f897c4ce1e7bc59edf883e03",
+  "source_commit": "464706647ccd2f6a7806bd6e74e4e060bc6b889d",
   "stagingFiles": [
     {
       "bytes": 495,
@@ -384,9 +384,9 @@
       "source": "tuning-geofeeds/packaging/release.json"
     },
     {
-      "bytes": 3452,
+      "bytes": 3281,
       "path": "CONTRIBUTING.md",
-      "sha256": "3bbb7a46bd35012a52f8417cac4a47a4e5cb1edd53e611bdea21ce75ce0b2eb3",
+      "sha256": "26e7e2a84fb7478c289954f3cc123e2f9e730634f0e92a7e34581527102afa95",
       "source": "tuning-geofeeds/packaging/public-root/CONTRIBUTING.md+tuning-geofeeds/packaging/release.json+pyproject.toml+schema/analysis.schema.json"
     },
     {
@@ -396,15 +396,15 @@
       "source": "tuning-geofeeds/packaging/public/LICENSE"
     },
     {
-      "bytes": 975,
+      "bytes": 938,
       "path": "MIGRATION.md",
-      "sha256": "4fffa6b2566ac6a9a4bfb8d9944d46c595e64a60615632f23ea07ae933b56741",
+      "sha256": "9edc6faee96513aa13412d3b0d5db8fc5bf95ec8781853dcaa61cfd502e00ebe",
       "source": "tuning-geofeeds/packaging/public-root/MIGRATION.md+tuning-geofeeds/packaging/release.json+pyproject.toml+schema/analysis.schema.json"
     },
     {
-      "bytes": 12850,
+      "bytes": 13683,
       "path": "README.md",
-      "sha256": "a6ea248efbb900656e11040eb9aa4dfab5a4f155e5b9727da6f9a029da5a10b8",
+      "sha256": "8405c9e782a0079eb7cf766348949b6ad91e0d087b6bdfb1ff17e45fc22afc1e",
       "source": "tuning-geofeeds/packaging/public-root/README.md+tuning-geofeeds/packaging/release.json+pyproject.toml+schema/analysis.schema.json"
     },
     {

--- a/tuning-geofeeds/SKILL.md
+++ b/tuning-geofeeds/SKILL.md
@@ -14,6 +14,13 @@ Use the bundled analyzer to inspect and improve an RFC 8805 feed without
 silently changing authored data. Keep one user-selected working directory for
 all generated files; never write runtime output into this skill directory.
 
+## Get the feed
+
+Claude Cowork, other cloud agents, and corporate networks may allow only listed
+HTTPS hosts. If the host cannot fetch the geofeed URL, ask the user to upload
+the CSV. That is the intended path. Do not bypass the host's network policy or
+reconstruct feed rows.
+
 ## Gotchas and invariants
 
 - **Fastah MCP receives only** `rowId`, `country`, `region`, `city`, and
@@ -71,23 +78,18 @@ Track these gates and do not skip from analysis to export:
 
 ### 1. Obtain a local source
 
-For a local or uploaded file, copy it into `WORK` without changing its bytes.
-For a public HTTPS URL, use only a host-managed download facility that fully
-downloads to `WORK`, uses no ambient credentials, rejects non-HTTPS and
-credential-bearing URLs, blocks private/loopback/link-local destinations on
-every redirect and connection, and enforces redirect, timeout, and size limits.
-If the host cannot guarantee those controls, stop and ask the user to upload
-the file; never substitute `curl`, `wget`, or an ad hoc downloader.
-The bundled runtime currently accepts only strict UTF-8 local files and cannot
-record raw-response and normalized digests. Do not transcode a remote response
-outside a provenance-preserving host acquisition facility. An absent charset
-means strict UTF-8, never a Latin-1 fallback; unsupported declarations and
-undeclared malformed UTF-8 must fail closed.
+Use a local or uploaded file, or the host's normal HTTPS download capability.
+If the host blocks the URL, ask the user to upload the CSV. Do not create a
+downloader or bypass network controls. The analyzer accepts strict UTF-8 local
+files. If conversion is needed, keep the original and make a separate UTF-8
+working copy.
 
 For named third-party operational examples, see the
 [Interpretation guide](references/interpretation.md#third-party-operational-examples).
 
 Set `INPUT` to that absolute local path.
+Analysis records `source.sha256` for audits and for binding later approvals to
+the analyzed file. Most users do not need to calculate a separate digest.
 
 ### 2. Analyze locally and present base findings
 
@@ -167,7 +169,10 @@ trigger a correction automatically. If MCP is unavailable, continue offline.
 The Analysis JSON itself is the JSON artifact. Renderers accept only validated
 IR and do not recompute findings. Explain output distinctions using
 [Interpretation guide](references/interpretation.md). Present the files through
-the host; the offline dashboard needs no server or Mapbox token.
+the host; the offline dashboard needs no server or Mapbox token. Offline or
+RDAP-only analysis has no point or bounds geometry. In that case GeoJSON is a
+valid empty FeatureCollection and the launcher prints an informational message;
+only MCP place evidence can populate its features.
 
 ### 6. Propose, review, and explicitly approve corrections
 

--- a/tuning-geofeeds/evals/evals.json
+++ b/tuning-geofeeds/evals/evals.json
@@ -165,6 +165,7 @@
       "assertions": [
         "Compatibility metadata states Python 3.14+",
         "The launcher contains an executable Python 3.14 runtime guard",
+        "The launcher rejects prerelease Python before loading the analyzer",
         "No alternate ad hoc analyzer is generated"
       ]
     },

--- a/tuning-geofeeds/package/Makefile
+++ b/tuning-geofeeds/package/Makefile
@@ -4,13 +4,13 @@ PYTHON_BOOTSTRAP ?= python3.14
 .PHONY: setup check-python format lint type test test-live-rdap schema-generate schema-check skill-validate skill-eval skill-release-check skill-package-check skill-package-build skill-public-stage check analyze render render-html export-geojson mcp-export mcp-import propose-corrections record-approval export-csv
 
 setup:
-	$(PYTHON_BOOTSTRAP) -c 'import sys; assert sys.version_info >= (3, 14), "Python 3.14 or newer is required"'
+	$(PYTHON_BOOTSTRAP) -c 'import sys; assert sys.version_info >= (3, 14) and sys.version_info.releaselevel == "final", "A final Python 3.14 or newer release is required"'
 	$(PYTHON_BOOTSTRAP) -m venv --clear .venv
 	$(PYTHON) -m pip install --upgrade pip
 	$(PYTHON) -m pip install -e '.[dev]'
 
 check-python:
-	$(PYTHON) -c 'import sys; assert sys.version_info >= (3, 14), "Python 3.14 or newer is required"'
+	$(PYTHON) -c 'import sys; assert sys.version_info >= (3, 14) and sys.version_info.releaselevel == "final", "A final Python 3.14 or newer release is required"'
 
 format:
 	$(PYTHON) -m ruff format src tests tuning-geofeeds/scripts

--- a/tuning-geofeeds/package/README.md
+++ b/tuning-geofeeds/package/README.md
@@ -1,7 +1,7 @@
 # Fastah geofeed quality analyzer
 
-Portable Python 3.14+ implementation bundled with the `tuning-geofeeds` Agent
-Skill. It parses public RFC 8805 geofeeds locally into a typed, versioned
+Portable final-release Python 3.14+ implementation bundled with the
+`tuning-geofeeds` Agent Skill. It parses public RFC 8805 geofeeds locally into a typed, versioned
 Analysis IR and provides deterministic validation, relationship analysis,
 optional direct-RIR RDAP evidence, host-mediated Fastah MCP exchange, IR-only
 renderers, and explicit approval-gated corrected CSV export.
@@ -20,5 +20,16 @@ cp -R "$PACKAGE_ROOT" /absolute/work-directory/tuning-geofeeds-runtime
 
 Install from the working copy, never from the read-only distribution tree;
 Python build frontends may write local build metadata beside their input.
+
+Verify that Python reports a final release, not an alpha, beta, or release
+candidate. If Python 3.14 is unavailable and current `uv` is already installed,
+`uv python install 3.14` and `uv venv --python 3.14 /absolute/work-directory/.venv`
+are supported alternatives. Do not assume `uv` exists. Update it through its
+trusted installation channel (`uv self update` is for standalone installs).
+
+If a cloud or corporate host cannot safely fetch an arbitrary public URL, ask
+the user to upload the CSV. Do not bypass the host's network policy or
+reconstruct the feed. Analysis records `source.sha256` for optional audits and
+for binding approvals to the analyzed file.
 
 The skill workflow and safety boundaries are in [`../SKILL.md`](../SKILL.md).

--- a/tuning-geofeeds/package/src/geofeed_quality/__init__.py
+++ b/tuning-geofeeds/package/src/geofeed_quality/__init__.py
@@ -1,12 +1,14 @@
 """Typed local geofeed analysis."""
+# ruff: noqa: E402 - runtime guard must run before Pydantic-backed imports
+
+from .runtime import require_supported_python
+
+require_supported_python()
 
 from .analyzer import MAX_DATA_ROWS, analyze_file
 from .corrections import export_corrected_csv, propose_corrections, record_approval
 from .errors import AnalysisError, CorrectionError, DataRowLimitError, SourceDecodeError
 from .models import Analysis, CorrectionApproval, CorrectionPlan
-from .runtime import require_supported_python
-
-require_supported_python()
 
 __all__ = [
     "MAX_DATA_ROWS",

--- a/tuning-geofeeds/package/src/geofeed_quality/cli.py
+++ b/tuning-geofeeds/package/src/geofeed_quality/cli.py
@@ -206,6 +206,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.command == "export-geojson":
             document = export_geojson_file(args.input)
             _write_atomic_new(args.output, (json.dumps(document, indent=2) + "\n").encode())
+            if not document["features"]:
+                print(
+                    "info: GeoJSON contains zero features because no MCP place evidence "
+                    "with valid coordinates or bounds is present",
+                    file=sys.stderr,
+                )
             return 0
         if args.command == "propose-corrections":
             document = json.loads(args.input.read_text(encoding="utf-8"))

--- a/tuning-geofeeds/package/src/geofeed_quality/runtime.py
+++ b/tuning-geofeeds/package/src/geofeed_quality/runtime.py
@@ -7,10 +7,20 @@ import sys
 MINIMUM_PYTHON = (3, 14)
 
 
-def require_supported_python(version: tuple[int, int] | None = None) -> None:
+def require_supported_python(
+    version: tuple[int, int] | None = None, *, releaselevel: str | None = None
+) -> None:
     actual = version or sys.version_info[:2]
     if actual < MINIMUM_PYTHON:
         raise RuntimeError(
             f"fastah-geofeed-quality requires Python {MINIMUM_PYTHON[0]}."
             f"{MINIMUM_PYTHON[1]} or newer; found {actual[0]}.{actual[1]}"
+        )
+    actual_releaselevel = releaselevel or (
+        sys.version_info.releaselevel if version is None else "final"
+    )
+    if actual_releaselevel != "final":
+        raise RuntimeError(
+            "fastah-geofeed-quality requires a final Python 3.14 or newer release; "
+            f"found prerelease {actual[0]}.{actual[1]} ({actual_releaselevel})"
         )

--- a/tuning-geofeeds/package/tests/test_cli.py
+++ b/tuning-geofeeds/package/tests/test_cli.py
@@ -27,7 +27,9 @@ def test_analyze_then_render_cli(tmp_path: Path) -> None:
     assert report_path.read_text().startswith("# Geofeed quality analysis\n")
 
 
-def test_html_and_geojson_cli_consume_analysis_json(tmp_path: Path) -> None:
+def test_html_and_geojson_cli_consume_analysis_json(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     analysis_path = tmp_path / "analysis.json"
     html_path = tmp_path / "dashboard.html"
     geojson_path = tmp_path / "analysis.geojson"
@@ -40,6 +42,10 @@ def test_html_and_geojson_cli_consume_analysis_json(tmp_path: Path) -> None:
         "features": [],
         "attribution": ["Contains information derived from GeoNames (https://www.geonames.org/)."],
     }
+    assert capsys.readouterr().err == (
+        "info: GeoJSON contains zero features because no MCP place evidence "
+        "with valid coordinates or bounds is present\n"
+    )
 
 
 def test_html_cli_reads_explicit_mapbox_token_file(tmp_path: Path) -> None:
@@ -195,7 +201,9 @@ def test_cli_preserves_output_when_one_rdap_assessment_is_malformed(
     assert "z" * 64 not in analysis_path.read_text()
 
 
-def test_cli_mcp_export_and_import_are_host_mediated(tmp_path: Path) -> None:
+def test_cli_mcp_export_and_import_are_host_mediated(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     analysis_path = tmp_path / "analysis.json"
     batches_path = tmp_path / "batches"
     enriched_path = tmp_path / "enriched.json"
@@ -249,6 +257,10 @@ def test_cli_mcp_export_and_import_are_host_mediated(tmp_path: Path) -> None:
         item["search_mode"] == "prefer_larger_population_center"
         for item in enriched["enrichment"]["mcp_observations"]
     )
+    geojson_path = tmp_path / "enriched.geojson"
+    assert main(["export-geojson", str(enriched_path), "--output", str(geojson_path)]) == 0
+    assert json.loads(geojson_path.read_text())["features"]
+    assert "zero features" not in capsys.readouterr().err
 
 
 def test_user_facing_outputs_refuse_existing_paths(

--- a/tuning-geofeeds/package/tests/test_public_packaging.py
+++ b/tuning-geofeeds/package/tests/test_public_packaging.py
@@ -87,16 +87,20 @@ def test_public_root_is_generated_from_canonical_metadata(tmp_path: Path) -> Non
         "around 225 MB",
         "remarks: Geofeed https://...",
         "https://mcp.fastah.ai/terms-of-use.txt",
+        "upload the CSV",
+        "source.sha256",
+        "valid empty FeatureCollection",
     ):
         assert text in readme
     assert "{{" not in readme
     assert "make skill-public-stage" not in readme
-    assert "Public and marketplace release remain blocked" in (
-        tmp_path / "CONTRIBUTING.md"
-    ).read_text(encoding="utf-8")
+    contributing = (tmp_path / "CONTRIBUTING.md").read_text(encoding="utf-8")
+    assert "local-file-first GitHub Skill is public" in contributing
+    assert "Marketplace release remains blocked" in contributing
     migration = (tmp_path / "MIGRATION.md").read_text(encoding="utf-8")
     assert "`tuning-geofeeds` supersedes the legacy `geofeed-tuner`" in migration
-    assert "will remove the legacy skill" in migration
+    assert "public migration removed the legacy skill" in migration
+    assert "future public migration" not in migration
 
     plugin = json.loads((tmp_path / ".github" / "plugin" / "plugin.json").read_text())
     assert plugin["name"] == config["pluginName"]

--- a/tuning-geofeeds/package/tests/test_runtime.py
+++ b/tuning-geofeeds/package/tests/test_runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
+import textwrap
 import tomllib
 from importlib.metadata import version
 from pathlib import Path
@@ -19,19 +20,62 @@ def test_runtime_floor_is_python_3_14() -> None:
     unsupported = (MINIMUM_PYTHON[0], MINIMUM_PYTHON[1] - 1)
     with pytest.raises(RuntimeError, match=r"requires Python 3\.14 or newer"):
         require_supported_python(unsupported)
+    with pytest.raises(RuntimeError, match=r"requires a final Python 3\.14 or newer release"):
+        require_supported_python(MINIMUM_PYTHON, releaselevel="candidate")
 
 
 def test_package_metadata_matches_runtime_floor() -> None:
-    metadata = tomllib.loads((Path(__file__).parents[1] / "pyproject.toml").read_text())
+    product = Path(__file__).parents[1]
+    metadata = tomllib.loads((product / "pyproject.toml").read_text())
     assert metadata["project"]["requires-python"] == ">=3.14"
     assert metadata["tool"]["ruff"]["target-version"] == "py314"
     assert metadata["tool"]["mypy"]["python_version"] == "3.14"
+    makefile = (product / "Makefile").read_text(encoding="utf-8")
+    assert makefile.count('sys.version_info.releaselevel == "final"') == 2
 
 
 def test_pycountry_dependency_floor_and_installed_version() -> None:
     metadata = tomllib.loads((Path(__file__).parents[1] / "pyproject.toml").read_text())
     assert "pycountry>=26.2.16" in metadata["project"]["dependencies"]
+    assert "pydantic>=2.11,<3" in metadata["project"]["dependencies"]
     assert Version(version("pycountry")) >= Version("26.2.16")
+
+
+def test_agent_launcher_rejects_prerelease_before_importing_pydantic() -> None:
+    launcher = (
+        Path(__file__).parents[1] / "tuning-geofeeds" / "scripts" / "geofeed_cli.py"
+    )
+    script = textwrap.dedent(
+        f"""
+        import importlib.util
+        import sys
+
+        class PrereleaseVersion(tuple):
+            releaselevel = "candidate"
+
+        spec = importlib.util.spec_from_file_location("prerelease_launcher", {str(launcher)!r})
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        module.sys.version_info = PrereleaseVersion((3, 14, 0, "candidate", 2))
+        module.sys.version = "3.14.0rc2"
+        module.sys.argv = [{str(launcher)!r}, "--help"]
+        assert "pydantic" not in sys.modules
+        try:
+            module.main()
+        except SystemExit as error:
+            assert "requires a final Python 3.14 or newer release" in str(error)
+        else:
+            raise AssertionError("prerelease launcher did not exit")
+        assert "pydantic" not in sys.modules
+        """
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
 
 
 def test_agent_launcher_help_exposes_examples_and_exit_meanings() -> None:

--- a/tuning-geofeeds/references/setup.md
+++ b/tuning-geofeeds/references/setup.md
@@ -1,13 +1,16 @@
 # Python setup
 
-The portable analyzer requires Python 3.14 or newer. Resolve the skill root
-from the installed skill location, change to that directory, then ask the
-bundled launcher where its package lives:
+The portable analyzer requires a final—not alpha, beta, or release
+candidate—Python 3.14 or newer. Resolve the skill root from the installed skill
+location and choose a user working directory:
 
 ```bash
 SKILL_ROOT="/absolute/path/to/tuning-geofeeds"
 cd "$SKILL_ROOT"
+WORK="/absolute/path/to/user-selected-work-directory"
+mkdir -p "$WORK"
 BOOTSTRAP_PYTHON="/absolute/path/to/python3.14"
+"$BOOTSTRAP_PYTHON" -c 'import sys; assert sys.version_info >= (3, 14) and sys.version_info.releaselevel == "final", sys.version'
 PACKAGE_ROOT="$("$BOOTSTRAP_PYTHON" scripts/geofeed_cli.py --print-package-root)"
 "$BOOTSTRAP_PYTHON" -m venv "$WORK/.venv"
 PYTHON="$WORK/.venv/bin/python"
@@ -15,6 +18,27 @@ RUNTIME_SOURCE="$WORK/tuning-geofeeds-runtime"
 cp -R "$PACKAGE_ROOT" "$RUNTIME_SOURCE"
 "$PYTHON" -m pip install "$RUNTIME_SOURCE"
 ```
+
+If Python 3.14 is unavailable and `uv` is already installed, it is an optional
+fallback. Keep `uv` current through the same trusted installation channel that
+provided it; `uv self update` applies to the standalone installer, while a
+package-managed installation should be updated by that package manager. Then:
+
+```bash
+uv python install 3.14
+BOOTSTRAP_PYTHON="$(uv python find 3.14)"
+"$BOOTSTRAP_PYTHON" -c 'import sys; assert sys.version_info >= (3, 14) and sys.version_info.releaselevel == "final", sys.version'
+PACKAGE_ROOT="$("$BOOTSTRAP_PYTHON" scripts/geofeed_cli.py --print-package-root)"
+uv venv --python 3.14 "$WORK/.venv"
+PYTHON="$WORK/.venv/bin/python"
+RUNTIME_SOURCE="$WORK/tuning-geofeeds-runtime"
+cp -R "$PACKAGE_ROOT" "$RUNTIME_SOURCE"
+uv pip install --python "$PYTHON" "$RUNTIME_SOURCE"
+```
+
+Do not assume `uv` exists, and do not weaken or pin runtime dependencies to
+support an obsolete Python prerelease. The launcher rejects prerelease Python
+before importing the analyzer or Pydantic.
 
 On Windows, use the virtual environment interpreter at
 `$WORK\.venv\Scripts\python.exe`. Windows users should install Python through
@@ -32,6 +56,12 @@ Run the launcher with the prepared interpreter:
 If the host cannot retain the skill root as its working directory, invoke the
 same launcher by its resolved absolute path. It does not resolve the bundled
 package relative to the caller's current directory.
+
+Cloud-agent and corporate networks often cannot fetch arbitrary HTTPS hosts.
+When that happens, ask the user to upload the CSV. This is the intended path.
+Do not bypass the host's network policy or reconstruct the feed. Analysis
+records `source.sha256` for optional audits and for binding approvals; users do
+not normally need to calculate another digest.
 
 The analyzer accepts at most 60,000 data rows. Comments and blank physical
 lines do not count. An oversized input fails before any Analysis IR is

--- a/tuning-geofeeds/scripts/evaluate.py
+++ b/tuning-geofeeds/scripts/evaluate.py
@@ -140,6 +140,8 @@ def _mcp(runner: Runner) -> list[Result]:
         "mcp-import",
         str(base),
         str(runner.files / "mcp-response-v1.json"),
+        "--mapping",
+        str(requests / "mapping.json"),
         "--batch-limit",
         "1000",
         "--output",
@@ -375,6 +377,10 @@ def _python_guard(runner: Runner) -> list[Result]:
     return [
         ("Requires Python 3.14+" in skill, "frontmatter compatibility requires Python 3.14+"),
         ("sys.version_info < (3, 14)" in launcher, "launcher has an executable version guard"),
+        (
+            'sys.version_info.releaselevel != "final"' in launcher,
+            "launcher rejects prerelease Python before loading the analyzer",
+        ),
         (None, "requires a clean agent execution trace"),
     ]
 

--- a/tuning-geofeeds/scripts/geofeed_cli.py
+++ b/tuning-geofeeds/scripts/geofeed_cli.py
@@ -26,6 +26,11 @@ def package_root() -> Path:
 def main() -> int:
     if sys.version_info < (3, 14):  # noqa: UP036 - portable runtime guard is intentional
         raise SystemExit("error: tuning-geofeeds requires Python 3.14 or newer")
+    if sys.version_info.releaselevel != "final":
+        raise SystemExit(
+            "error: tuning-geofeeds requires a final Python 3.14 or newer release; "
+            f"found prerelease {sys.version.split()[0]}"
+        )
     root = package_root()
     if sys.argv[1:] == ["--print-package-root"]:
         print(root)


### PR DESCRIPTION
## Summary
- explain the intended upload fallback for Claude Cowork, cloud agents, and allowlisted corporate networks
- add optional current-`uv` setup guidance and reject prerelease Python before loading Pydantic
- explain empty offline GeoJSON and emit a concise informational CLI message
- update public migration/readiness wording and package regression coverage

Generated exactly from private monorepo source `464706647ccd2f6a7806bd6e74e4e060bc6b889d` after merged PR #1805.

## Feedback decisions
- accepted upload-fallback, optional `uv`, final-Python guard, and empty-GeoJSON guidance
- retained the existing `pydantic>=2.11,<3` range; the field report’s claim that no floor existed was incorrect
- did not ship the supplied downloader because its URL parsing and redirect handling do not meet the Skill’s safety boundary

## Verification
- canonical package and public-stage checks passed under Python 3.14.7 final
- public tree matches all 67 generated files byte-for-byte
- manifest SHA-256: `226e1785ee0597ca6e8a42642622c63131b8ecf2fced9839d0165746ba97739e`
- no secrets, private paths, runtime captures, or `.egg-info`
- `publicationPerformed=false`
- `git diff --check` passes

This PR updates the public repository only. It does not publish to a marketplace or change production services.