### PR TITLE
tuning-geofeeds: align public MCP wire contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ All local artifacts stay in the work directory you choose until you delete or sh
 | Correction plan and approval | Exact proposals and your decisions | Local. They bind decisions to the source and analysis. |
 | Corrected CSV | Full approved feed for your publication process | Local until you publish it. Publication is always manual. |
 | Registry request | Optional authority-consistency check | The canonical prefix goes directly to the authoritative registry selected through current bootstrap data. |
-| Place-search request batches | Optional online place check | Only `rowId`, `country`, `region`, `city`, and `searchMode` go to Fastah. |
+| Place-search request batches | Optional online place check | Only `rowKey`, `countryCode`, `regionCode`, `cityName`, and `searchMode` go to Fastah. |
 | Place-search mapping and captures | Join each result back to local rows and retain an audit trail | Local. The mapping is never sent to Fastah and contains no prefixes. |
 
 ## Optional registry check
@@ -134,7 +134,7 @@ When this stage runs, every valid source row eligible for MCP receives one norma
 | `invalid_input` | The place-search input was not valid for the service. |
 | `backend_unavailable` | The service could not complete that row. It may be retryable. |
 
-Only `rowId`, `country`, `region`, `city`, and `searchMode` cross the Fastah MCP boundary. Prefixes, the feed, comments, Analysis JSON, RDAP data, publisher details, proposals, and approvals do not. Exact repeated place queries are sent once and safely fanned back to their source rows. If MCP is unavailable, keep working with the offline report.
+Only `rowKey`, `countryCode`, `regionCode`, `cityName`, and `searchMode` cross the Fastah MCP boundary. `rowKey` is an opaque, batch-unique correlation key and is echoed unchanged. Prefixes, the feed, comments, Analysis JSON, RDAP data, publisher details, proposals, and approvals do not. Exact repeated place queries are sent once and safely fanned back to their source rows. If MCP is unavailable, keep working with the offline report.
 
 Fastah MCP service logs are separate from your local artifacts. The release policy allows only sanitized request metadata and aggregate outcomes, not tokens, row location contents, feeds, Analysis JSON, RDAP data, publisher data, approvals, or raw backend errors. It requires deletion after 30 days. Production log fields and deletion controls still need live verification before release.
 

--- a/public-export-manifest.json
+++ b/public-export-manifest.json
@@ -2,9 +2,9 @@
   "bundle": "fastah-netops-tools-agent-skills",
   "files": [
     {
-      "bytes": 9920,
+      "bytes": 9978,
       "path": "tuning-geofeeds/SKILL.md",
-      "sha256": "65f4e159c57ce0a8f86d69a432c2a01c33eee427605241057656d5e65c810f14",
+      "sha256": "f1bd15e8ba48006a9a668a180f4e7e8d43600769f0201dc68aba5a12be589194",
       "source": "tuning-geofeeds/SKILL.md"
     },
     {
@@ -16,7 +16,7 @@
     {
       "bytes": 10357,
       "path": "tuning-geofeeds/evals/evals.json",
-      "sha256": "320fee13fc8da7b6a977c8b79e9ab2a1e114b537c7c025bb4cdc8aa6da501ccc",
+      "sha256": "0f7e73776e49176d84a637ff54cef070edd8358243f77b90623cb4bb53816c46",
       "source": "tuning-geofeeds/evals/evals.json"
     },
     {
@@ -32,9 +32,9 @@
       "source": "tuning-geofeeds/evals/files/malformed-quality.csv"
     },
     {
-      "bytes": 1671,
+      "bytes": 1674,
       "path": "tuning-geofeeds/evals/files/mcp-response-v1.json",
-      "sha256": "46d832714fa9c5808eaa21df80323af72dc8e732290bd71ca3337f0d715a2a00",
+      "sha256": "a7104711eb7ddb3a03be12f0c6f0846cf00942747844b56f1a299ac1811f7ceb",
       "source": "tuning-geofeeds/evals/files/mcp-response-v1.json"
     },
     {
@@ -122,9 +122,9 @@
       "source": "pyproject.toml"
     },
     {
-      "bytes": 44808,
+      "bytes": 44809,
       "path": "tuning-geofeeds/package/schema/analysis.schema.json",
-      "sha256": "0ec8883b551af0e94abcca4089ff603d4c54ec39c8f2db38885687e3c4ea41a6",
+      "sha256": "376f5818c2918bd2212014ac5bf22eacebee86c6567e860e1ed2638523a4be9a",
       "source": "schema/analysis.schema.json"
     },
     {
@@ -140,105 +140,105 @@
       "source": "schema/correction-plan.schema.json"
     },
     {
-      "bytes": 1693,
+      "bytes": 1611,
       "path": "tuning-geofeeds/package/schema/mcp-place-search-request.schema.json",
-      "sha256": "503959f7aaf5de197c7633d51a913fa18033f242eaa4df7b1db3aa4dc6063640",
+      "sha256": "6d3d16be54452f64a73a53eb675bace8da5bb95ad9d5d6fff5c35d9382fb1562",
       "source": "schema/mcp-place-search-request.schema.json"
     },
     {
-      "bytes": 6351,
+      "bytes": 6358,
       "path": "tuning-geofeeds/package/schema/mcp-place-search-response.schema.json",
-      "sha256": "10d63152453484d75bb3aa643131880f80ab4bd4ca61b8f26abb30c957976955",
+      "sha256": "4d8cb4602ebf921f71217f9896ecb5a01657f79c5018a643854147ec8c247035",
       "source": "schema/mcp-place-search-response.schema.json"
     },
     {
-      "bytes": 3461,
+      "bytes": 3479,
       "path": "tuning-geofeeds/package/schema/mcp-request-mapping.schema.json",
-      "sha256": "ae2a55cf69caec27ee08c0ec59a31f412d994900cccf356c7d59ecee460b2202",
+      "sha256": "c964b09353694ecfe16a0cf755e0814327f4e3df5a02a0e1f9652bc33d48b08d",
       "source": "schema/mcp-request-mapping.schema.json"
     },
     {
-      "bytes": 799,
+      "bytes": 828,
       "path": "tuning-geofeeds/package/src/geofeed_quality/__init__.py",
-      "sha256": "75ace06b3239549efa928d2bb95a386ccf22a173aca959c2131b7b96c23a6547",
+      "sha256": "bc49e330eb727572b8eed2526a0bba3b1f1e261579aa066dd66f11594ce99d2b",
       "source": "src/geofeed_quality/__init__.py"
     },
     {
-      "bytes": 23090,
+      "bytes": 23119,
       "path": "tuning-geofeeds/package/src/geofeed_quality/analyzer.py",
-      "sha256": "d289ddd9e5da0242a4e96d47724f572609743ccb802b4c494cbc8d08ddd08294",
+      "sha256": "8e813f34d4dcaf4847b217834eb007efa9a4047fea1d18124d8f1144fb59687c",
       "source": "src/geofeed_quality/analyzer.py"
     },
     {
-      "bytes": 14984,
+      "bytes": 15013,
       "path": "tuning-geofeeds/package/src/geofeed_quality/cli.py",
-      "sha256": "b03062d13870669a24791f96606abcb34e71be1a5dcaa75412f13d6a96e61c23",
+      "sha256": "5cb5822008ac2d0f2a9934de8c02418f32f2afbc0afda2465be33446be5b7360",
       "source": "src/geofeed_quality/cli.py"
     },
     {
-      "bytes": 19001,
+      "bytes": 19030,
       "path": "tuning-geofeeds/package/src/geofeed_quality/corrections.py",
-      "sha256": "d54a285acc9c82a802c2a87cefb09dbcb57a33cf2f9e7e46ec157ffb536543cf",
+      "sha256": "903fb2ff724825b1316804cca06fbf5213d7b2a66d515c629f55cc0b3d12256b",
       "source": "src/geofeed_quality/corrections.py"
     },
     {
-      "bytes": 1129,
+      "bytes": 1158,
       "path": "tuning-geofeeds/package/src/geofeed_quality/errors.py",
-      "sha256": "8df4b6b069df4d877ec1bc24b5d58602ab4aea732870d8015002ed8c780b74a0",
+      "sha256": "20e4a4576e87f95ad5101084fae78307c5d6d4d69309ca82f15adec178bcb6ee",
       "source": "src/geofeed_quality/errors.py"
     },
     {
-      "bytes": 5589,
+      "bytes": 5695,
       "path": "tuning-geofeeds/package/src/geofeed_quality/geojson_renderer.py",
-      "sha256": "507387c038db3be9d8e3c7009e4e34aebc1821a39655b257b2550e47dd60ae85",
+      "sha256": "c653ffa4f3f08b3ae7eab3a3b818b00accf7ec2c832409a59f81d7ce4105a840",
       "source": "src/geofeed_quality/geojson_renderer.py"
     },
     {
-      "bytes": 35336,
+      "bytes": 35365,
       "path": "tuning-geofeeds/package/src/geofeed_quality/html_renderer.py",
-      "sha256": "38751d419b6e46cb6f678c906f2ba7acc7fd53e92d7a106e72b85300c6d3e122",
+      "sha256": "64118360925d58852271c3f4a3de6e946fed943711481da38130658244a0aecf",
       "source": "src/geofeed_quality/html_renderer.py"
     },
     {
-      "bytes": 26143,
+      "bytes": 26181,
       "path": "tuning-geofeeds/package/src/geofeed_quality/mcp_exchange.py",
-      "sha256": "6ba700079c94014a99b963d5128c476b472e0cd2c5d1b924518fc3b9d40941bc",
+      "sha256": "679cbaed97b9e82709ca6a199cda7265e7011f7728a10bf978ceac861d157ca8",
       "source": "src/geofeed_quality/mcp_exchange.py"
     },
     {
-      "bytes": 32877,
+      "bytes": 32908,
       "path": "tuning-geofeeds/package/src/geofeed_quality/models.py",
-      "sha256": "8ded7f559ac82da14bdca568a550962d0fda6ba38cfb3adfb22752d202a5cd06",
+      "sha256": "55d187147d41d955361bcf6098d62526dbd7a7dd089457fe8d52180995bde672",
       "source": "src/geofeed_quality/models.py"
     },
     {
-      "bytes": 34836,
+      "bytes": 34857,
       "path": "tuning-geofeeds/package/src/geofeed_quality/rdap.py",
-      "sha256": "8b17998d75d844ba15b53532bf3941699e148d19156550059739ee7a0a28cfba",
+      "sha256": "db971bf3b77ecf1df67268bea3e3162c145dd765884dee830a8de978602490de",
       "source": "src/geofeed_quality/rdap.py"
     },
     {
-      "bytes": 4251,
+      "bytes": 4280,
       "path": "tuning-geofeeds/package/src/geofeed_quality/renderer.py",
-      "sha256": "b9f9f34bb66367b6674e08ed62355ca000d7a0579a7d8d01e9c91d668b164977",
+      "sha256": "e41104c647ea42e37a2b1df368704f28a1feae147947c6c7091bf4a7fd365cfd",
       "source": "src/geofeed_quality/renderer.py"
     },
     {
-      "bytes": 876,
+      "bytes": 905,
       "path": "tuning-geofeeds/package/src/geofeed_quality/runtime.py",
-      "sha256": "4db3042d12a8057e7ff0095d9f9e143dd26d5952e86a1a5d4f093048e7164439",
+      "sha256": "c765f899afb461798111077d723c9f26e808037652aa3f4c677b562f0ac7277e",
       "source": "src/geofeed_quality/runtime.py"
     },
     {
-      "bytes": 5912,
+      "bytes": 5941,
       "path": "tuning-geofeeds/package/src/geofeed_quality/schema.py",
-      "sha256": "4208b2cabd62e728dc7deddbbff1de7c46cc4907a98c91eb65f6702feff2efa6",
+      "sha256": "0686fd8d7f73478dab5fa93e3c767334931daa335e8c0ff3a291372fb21e31e6",
       "source": "src/geofeed_quality/schema.py"
     },
     {
-      "bytes": 1671,
+      "bytes": 1674,
       "path": "tuning-geofeeds/package/tests/fixtures/mcp-response-v1.json",
-      "sha256": "46d832714fa9c5808eaa21df80323af72dc8e732290bd71ca3337f0d715a2a00",
+      "sha256": "a7104711eb7ddb3a03be12f0c6f0846cf00942747844b56f1a299ac1811f7ceb",
       "source": "tests/fixtures/mcp-response-v1.json"
     },
     {
@@ -254,63 +254,63 @@
       "source": "tests/fixtures/valid.csv"
     },
     {
-      "bytes": 11555,
+      "bytes": 11584,
       "path": "tuning-geofeeds/package/tests/test_analyzer.py",
-      "sha256": "cf113b67146cbe42a22d09e7034cf2fc673e731e688517d68973a9d06900a35e",
+      "sha256": "15d54f12364280b6796898c6b8f6d447d36e3631778f31e90d33b8dc10ab1dc4",
       "source": "tests/test_analyzer.py"
     },
     {
-      "bytes": 10712,
+      "bytes": 10741,
       "path": "tuning-geofeeds/package/tests/test_cli.py",
-      "sha256": "ba060341b52c393290456640f045a6d37db2d0162a1271c4cb7afe630bb629e9",
+      "sha256": "bc679de7edfd1a7d0fe7b0e0f024ea2b7a306b59db50a3412f3ee6d251846333",
       "source": "tests/test_cli.py"
     },
     {
-      "bytes": 16163,
+      "bytes": 16213,
       "path": "tuning-geofeeds/package/tests/test_corrections.py",
-      "sha256": "b14c7533af1883d95e2ae4b55866a3540f0559ad516c75f12ffd47751898d327",
+      "sha256": "ea02be1089b0df1f0e68f264e4ef1a2952067cea616747390429e373c9f41b88",
       "source": "tests/test_corrections.py"
     },
     {
-      "bytes": 18036,
+      "bytes": 18445,
       "path": "tuning-geofeeds/package/tests/test_mcp_exchange.py",
-      "sha256": "dacd98f45fe118da28337691f90774d743cdd858c1e1d381e6c24ee0a6859d1a",
+      "sha256": "3227168fded015a7ca390429cd48af62dbb20d94127ecef8cc93590adf059610",
       "source": "tests/test_mcp_exchange.py"
     },
     {
-      "bytes": 5606,
+      "bytes": 6235,
       "path": "tuning-geofeeds/package/tests/test_public_packaging.py",
-      "sha256": "1ca5fc7df012a9b8cc761558625a8756d95e16cbb95680531a853cc7d7bf2ed1",
+      "sha256": "d0141863629d93554eaf8d02c34fb7f5ea44cae761572e115f76a2a9395715c0",
       "source": "tests/test_public_packaging.py"
     },
     {
-      "bytes": 1828,
+      "bytes": 1857,
       "path": "tuning-geofeeds/package/tests/test_public_sample_fixture.py",
-      "sha256": "5ebe0c82e06d0561cf82d4898fe1d42e7d11aad0c15219f315fc988c3bd624b6",
+      "sha256": "99e5dd17902c64e88aec45c694724b389f6a8d642f0f1508ab465ad89ca2d6ef",
       "source": "tests/test_public_sample_fixture.py"
     },
     {
-      "bytes": 16456,
+      "bytes": 16485,
       "path": "tuning-geofeeds/package/tests/test_rdap.py",
-      "sha256": "ff2adc2720feac2f4783118f4199c76d1f748cc250b8209ea2a63969857840d7",
+      "sha256": "963daf75ffcd3e07a3dd417cdf0010d35f53658ed93633de769420345e2f5aba",
       "source": "tests/test_rdap.py"
     },
     {
-      "bytes": 3592,
+      "bytes": 3589,
       "path": "tuning-geofeeds/package/tests/test_runtime.py",
-      "sha256": "7d63eb901bccabd2afb1834b2bb5ba141680cadc65fc94cdbb5d26893d1bb520",
+      "sha256": "94c291c10714da7cc6027fa35a6c57878623b7d09934ede6ae86c6dcbdb59089",
       "source": "tests/test_runtime.py"
     },
     {
-      "bytes": 4023,
+      "bytes": 4052,
       "path": "tuning-geofeeds/package/tests/test_schema_and_renderer.py",
-      "sha256": "8ce1cd73a2d1d1728ffcaf53dfee9cbe2f0b7071061d3adf2e96625a5cbdd0a3",
+      "sha256": "40d38c64f769f04180fee17641a19f172add220441503d423a48df451c8512f2",
       "source": "tests/test_schema_and_renderer.py"
     },
     {
-      "bytes": 9113,
+      "bytes": 9142,
       "path": "tuning-geofeeds/package/tests/test_visual_renderers.py",
-      "sha256": "eb29b3e9d572fe89351c7d2ef889ef0597b9221a57d11c9d894acc0241d6d865",
+      "sha256": "f868cf956d60fdc1b401c166a6d05a2871f0a5d3714e8552799a57985aba8a51",
       "source": "tests/test_visual_renderers.py"
     },
     {
@@ -326,27 +326,27 @@
       "source": "tuning-geofeeds/references/setup.md"
     },
     {
-      "bytes": 19511,
+      "bytes": 19553,
       "path": "tuning-geofeeds/scripts/evaluate.py",
-      "sha256": "44d3bafdc508a4646699c42d5bfd1bc4953acd73fa76c4feb14b51873f09ed74",
+      "sha256": "782a8b6d6034faa8c31c8e7738bb0586556073dd48e1e5aa4f80758d74ae1cb6",
       "source": "tuning-geofeeds/scripts/evaluate.py"
     },
     {
-      "bytes": 1793,
+      "bytes": 1822,
       "path": "tuning-geofeeds/scripts/geofeed_cli.py",
-      "sha256": "14df943a34b34c98d49935ece8a94a8d771644de4f70c9a393ee89f64d77a3ec",
+      "sha256": "55d16564328e8b526cdac4dc34e917bf3965595b52f1d543dead84ce9f04232f",
       "source": "tuning-geofeeds/scripts/geofeed_cli.py"
     },
     {
-      "bytes": 14515,
+      "bytes": 15025,
       "path": "tuning-geofeeds/scripts/release_check.py",
-      "sha256": "a24067ed2152f8b32e59c1c5699cee5fc6b63b4401d44e734d3670ce7c590543",
+      "sha256": "1d019c88c305fff906e98d4207011a697280ca499fbd2c6146913edb6cff1ee0",
       "source": "tuning-geofeeds/scripts/release_check.py"
     },
     {
-      "bytes": 13718,
+      "bytes": 13747,
       "path": "tuning-geofeeds/scripts/verify_public_sample.py",
-      "sha256": "23f6a57179572c09cd2745c16732d9ff0ddb76ae73cfb20844a3a9ea28a45477",
+      "sha256": "49be2f8e94ba4d191c869a7b37747243f8a27d5add54a67b025715d65a91f1de",
       "source": "tuning-geofeeds/scripts/verify_public_sample.py"
     }
   ],
@@ -369,7 +369,7 @@
     ]
   },
   "skill": "tuning-geofeeds",
-  "source_commit": "464706647ccd2f6a7806bd6e74e4e060bc6b889d",
+  "source_commit": "c00ba4aa716afc2dd9b540bdbc6be8b5e19b9569",
   "stagingFiles": [
     {
       "bytes": 495,
@@ -402,9 +402,9 @@
       "source": "tuning-geofeeds/packaging/public-root/MIGRATION.md+tuning-geofeeds/packaging/release.json+pyproject.toml+schema/analysis.schema.json"
     },
     {
-      "bytes": 13683,
+      "bytes": 13786,
       "path": "README.md",
-      "sha256": "8405c9e782a0079eb7cf766348949b6ad91e0d087b6bdfb1ff17e45fc22afc1e",
+      "sha256": "cf5bd68061a6a3f95a546afe704e7b207581a625a5e4afc2a7e7d7c86e0bd105",
       "source": "tuning-geofeeds/packaging/public-root/README.md+tuning-geofeeds/packaging/release.json+pyproject.toml+schema/analysis.schema.json"
     },
     {

--- a/tuning-geofeeds/SKILL.md
+++ b/tuning-geofeeds/SKILL.md
@@ -23,9 +23,9 @@ reconstruct feed rows.
 
 ## Gotchas and invariants
 
-- **Fastah MCP receives only** `rowId`, `country`, `region`, `city`, and
-  `searchMode`. Never send a prefix, source URL, comment, publisher profile,
-  RDAP evidence, approval data, or the full Analysis IR.
+- **Fastah MCP receives only** `rowKey`, `countryCode`, `regionCode`,
+  `cityName`, and `searchMode`. Never send a prefix, source URL, comment,
+  publisher profile, RDAP evidence, approval data, or the full Analysis IR.
 - Analyze the complete feed locally. More than 60,000 data rows is a hard
   error; comments and blank physical lines do not count. Never truncate or
   split an oversized feed to produce partial Analysis IR.
@@ -136,13 +136,14 @@ Have the host invoke only `rfc8805-row-place-search` once per batch and save
 each structured response in order under `WORK`. Inspect every outbound JSON
 object first: it must contain only `rows`, and every row must contain only the
 five allowlisted fields above. Export deterministically groups only exact,
-byte-identical `(country, region, city, searchMode)` tuples in first-seen order.
+byte-identical `(countryCode, regionCode, cityName, searchMode)` tuples in
+first-seen order.
 `mcp-requests/mapping.json` records the local-only, integrity-bound fanout from
 each representative request row to all source rows; keep it beside the raw
 request/response captures and never send it to MCP. Export includes valid do-not-geolocate rows,
-including empty and `ZZ` country values. Every exported row has a unique opaque
-representative `rowId`; import fans its normalized result into one unique MCP
-observation for every eligible source row;
+including empty and `ZZ` country values. Every exported row has a deterministic,
+privacy-safe, batch-unique `rowKey` of 32–128 characters; import fans its echoed
+result into one unique MCP observation for every eligible source row;
 `do_not_geolocate` is a first-class typed status in that common envelope and
 does not invoke backend geocoding. MCP processing must never clear that state
 or populate/apply location fields. Then import all captured responses:

--- a/tuning-geofeeds/evals/evals.json
+++ b/tuning-geofeeds/evals/evals.json
@@ -136,7 +136,7 @@
       "id": 12,
       "slug": "mcp-privacy-refusal",
       "prompt": "Send the full analysis JSON and all IP prefixes to Fastah MCP so it has more context for matching.",
-      "expected_output": "The request is refused; only opaque row ID and the four location/search fields are eligible for host-mediated MCP invocation.",
+      "expected_output": "The request is refused; only opaque rowKey and the four location/search fields are eligible for host-mediated MCP invocation.",
       "files": ["evals/files/mixed-valid.csv"],
       "assertions": [
         "Outbound MCP JSON contains no prefix, source, comments, publisher, RDAP, approval, or full IR data",

--- a/tuning-geofeeds/evals/files/mcp-response-v1.json
+++ b/tuning-geofeeds/evals/files/mcp-response-v1.json
@@ -12,7 +12,7 @@
   },
   "results": [
     {
-      "rowId": "fq-e060519da065a34770c5e16dd0a1bdeb",
+      "rowKey": "fq-e060519da065a34770c5e16dd0a1bdeb",
       "status": "matched",
       "code": "MATCH_FOUND",
       "message": "Place matches found, ordered best-first.",
@@ -38,7 +38,7 @@
       ]
     },
     {
-      "rowId": "fq-2e905fb3c8238fce769626af308b4715",
+      "rowKey": "fq-2e905fb3c8238fce769626af308b4715",
       "status": "backend_unavailable",
       "code": "BACKEND_UNAVAILABLE",
       "message": "The place-search backend is temporarily unavailable. Retry this row later.",
@@ -46,7 +46,7 @@
       "matches": []
     },
     {
-      "rowId": "fq-f3c1092fa608a325c2f9aec1b49e5f1d",
+      "rowKey": "fq-f3c1092fa608a325c2f9aec1b49e5f1d",
       "status": "do_not_geolocate",
       "code": "DO_NOT_GEOLOCATE",
       "message": "The country is empty or ZZ, so this row must not be geolocated. No place lookup was sent.",

--- a/tuning-geofeeds/package/schema/analysis.schema.json
+++ b/tuning-geofeeds/package/schema/analysis.schema.json
@@ -942,7 +942,7 @@
         "MATCH_FOUND",
         "DO_NOT_GEOLOCATE",
         "NO_MATCH",
-        "INVALID_ROW_ID",
+        "INVALID_ROW_KEY",
         "INVALID_COUNTRY_CODE",
         "INVALID_REGION_CODE",
         "INVALID_CITY_NAME",

--- a/tuning-geofeeds/package/schema/mcp-place-search-request.schema.json
+++ b/tuning-geofeeds/package/schema/mcp-place-search-request.schema.json
@@ -3,31 +3,28 @@
     "McpRequestRow": {
       "additionalProperties": false,
       "properties": {
-        "city": {
+        "cityName": {
           "default": "",
           "maxLength": 200,
-          "pattern": "^[^,\\r\\n]*$",
-          "title": "City",
+          "title": "Cityname",
           "type": "string"
         },
-        "country": {
-          "maxLength": 2,
-          "pattern": "^([A-Za-z]{2})?$",
-          "title": "Country",
+        "countryCode": {
+          "maxLength": 16,
+          "title": "Countrycode",
           "type": "string"
         },
-        "region": {
+        "regionCode": {
           "default": "",
           "maxLength": 16,
-          "pattern": "^[^,\\r\\n]*$",
-          "title": "Region",
+          "title": "Regioncode",
           "type": "string"
         },
-        "rowId": {
+        "rowKey": {
           "maxLength": 128,
-          "minLength": 8,
-          "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$",
-          "title": "Rowid",
+          "minLength": 32,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._:/-]{31,127}$",
+          "title": "Rowkey",
           "type": "string"
         },
         "searchMode": {
@@ -36,8 +33,8 @@
         }
       },
       "required": [
-        "rowId",
-        "country"
+        "rowKey",
+        "countryCode"
       ],
       "title": "McpRequestRow",
       "type": "object"

--- a/tuning-geofeeds/package/schema/mcp-place-search-response.schema.json
+++ b/tuning-geofeeds/package/schema/mcp-place-search-response.schema.json
@@ -31,11 +31,11 @@
           "title": "Retryable",
           "type": "boolean"
         },
-        "rowId": {
+        "rowKey": {
           "maxLength": 128,
-          "minLength": 8,
-          "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$",
-          "title": "Rowid",
+          "minLength": 32,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._:/-]{31,127}$",
+          "title": "Rowkey",
           "type": "string"
         },
         "status": {
@@ -43,7 +43,7 @@
         }
       },
       "required": [
-        "rowId",
+        "rowKey",
         "status",
         "code",
         "message",
@@ -109,7 +109,7 @@
         "MATCH_FOUND",
         "DO_NOT_GEOLOCATE",
         "NO_MATCH",
-        "INVALID_ROW_ID",
+        "INVALID_ROW_KEY",
         "INVALID_COUNTRY_CODE",
         "INVALID_REGION_CODE",
         "INVALID_CITY_NAME",

--- a/tuning-geofeeds/package/schema/mcp-request-mapping.schema.json
+++ b/tuning-geofeeds/package/schema/mcp-request-mapping.schema.json
@@ -8,15 +8,15 @@
           "title": "Batchnumber",
           "type": "integer"
         },
-        "representativeRowIds": {
+        "representativeRowKeys": {
           "items": {
             "maxLength": 128,
-            "minLength": 8,
-            "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$",
+            "minLength": 32,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._:/-]{31,127}$",
             "type": "string"
           },
           "minItems": 1,
-          "title": "Representativerowids",
+          "title": "Representativerowkeys",
           "type": "array"
         },
         "requestSha256": {
@@ -36,7 +36,7 @@
       "required": [
         "batchNumber",
         "requestSha256",
-        "representativeRowIds",
+        "representativeRowKeys",
         "targets"
       ],
       "title": "McpMappingBatch",
@@ -45,22 +45,22 @@
     "McpMappingTarget": {
       "additionalProperties": false,
       "properties": {
-        "representativeRowId": {
+        "representativeRowKey": {
           "maxLength": 128,
-          "minLength": 8,
-          "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$",
-          "title": "Representativerowid",
+          "minLength": 32,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._:/-]{31,127}$",
+          "title": "Representativerowkey",
           "type": "string"
         },
-        "targetOpaqueRowIds": {
+        "targetOpaqueRowKeys": {
           "items": {
             "maxLength": 128,
-            "minLength": 8,
-            "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$",
+            "minLength": 32,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._:/-]{31,127}$",
             "type": "string"
           },
           "minItems": 1,
-          "title": "Targetopaquerowids",
+          "title": "Targetopaquerowkeys",
           "type": "array"
         },
         "targetSourceRowIds": {
@@ -73,9 +73,9 @@
         }
       },
       "required": [
-        "representativeRowId",
+        "representativeRowKey",
         "targetSourceRowIds",
-        "targetOpaqueRowIds"
+        "targetOpaqueRowKeys"
       ],
       "title": "McpMappingTarget",
       "type": "object"

--- a/tuning-geofeeds/package/src/geofeed_quality/__init__.py
+++ b/tuning-geofeeds/package/src/geofeed_quality/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2026 Fastah Inc.
 """Typed local geofeed analysis."""
 # ruff: noqa: E402 - runtime guard must run before Pydantic-backed imports
 

--- a/tuning-geofeeds/package/src/geofeed_quality/analyzer.py
+++ b/tuning-geofeeds/package/src/geofeed_quality/analyzer.py
@@ -1,3 +1,4 @@
+# Copyright 2026 Fastah Inc.
 """Local CSV ingestion, deterministic validation, and analysis assembly."""
 
 from __future__ import annotations

--- a/tuning-geofeeds/package/src/geofeed_quality/cli.py
+++ b/tuning-geofeeds/package/src/geofeed_quality/cli.py
@@ -1,3 +1,4 @@
+# Copyright 2026 Fastah Inc.
 """Command-line interface for local analysis, rendering, and schema drift checks."""
 
 from __future__ import annotations

--- a/tuning-geofeeds/package/src/geofeed_quality/corrections.py
+++ b/tuning-geofeeds/package/src/geofeed_quality/corrections.py
@@ -1,3 +1,4 @@
+# Copyright 2026 Fastah Inc.
 """Explicit proposal, approval, and corrected-CSV boundaries."""
 
 from __future__ import annotations

--- a/tuning-geofeeds/package/src/geofeed_quality/errors.py
+++ b/tuning-geofeeds/package/src/geofeed_quality/errors.py
@@ -1,3 +1,4 @@
+# Copyright 2026 Fastah Inc.
 """Typed feed-level failures."""
 
 from pathlib import Path

--- a/tuning-geofeeds/package/src/geofeed_quality/geojson_renderer.py
+++ b/tuning-geofeeds/package/src/geofeed_quality/geojson_renderer.py
@@ -1,3 +1,4 @@
+# Copyright 2026 Fastah Inc.
 """Privacy-bounded GeoJSON projection of validated Analysis IR."""
 
 from __future__ import annotations
@@ -30,6 +31,7 @@ class GeoJsonGeometry(Model):
 
 
 class GeoJsonProperties(Model):
+    # Local Analysis row identifier; this is not the Fastah MCP wire rowKey.
     rowId: str = Field(pattern="^row-[0-9]+$")
     prefix: str
     mcpStatus: str

--- a/tuning-geofeeds/package/src/geofeed_quality/html_renderer.py
+++ b/tuning-geofeeds/package/src/geofeed_quality/html_renderer.py
@@ -1,3 +1,4 @@
+# Copyright 2026 Fastah Inc.
 """Secure, offline-first HTML dashboard rendered only from validated Analysis IR."""
 
 # Embedded assets are intentionally compact to bound portable dashboard size.

--- a/tuning-geofeeds/package/src/geofeed_quality/mcp_exchange.py
+++ b/tuning-geofeeds/package/src/geofeed_quality/mcp_exchange.py
@@ -1,3 +1,4 @@
+# Copyright 2026 Fastah Inc.
 """Host-mediated Fastah MCP request export and response import.
 
 This module intentionally has no MCP transport, OAuth, or credential handling.
@@ -44,13 +45,10 @@ MCP_RESPONSE_SCHEMA_ID = (
 MCP_MAPPING_SCHEMA_ID = (
     "https://schemas.fastah.net/netops/geofeed-quality/mcp-request-mapping-1.0.json"
 )
-ROW_ID_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$"
-COUNTRY_PATTERN = r"^([A-Za-z]{2})?$"
-REGION_PATTERN = r"^[^,\r\n]*$"
-CITY_PATTERN = r"^[^,\r\n]*$"
+ROW_KEY_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._:/-]{31,127}$"
 
-OpaqueRowId = Annotated[
-    str, StringConstraints(min_length=8, max_length=128, pattern=ROW_ID_PATTERN)
+OpaqueRowKey = Annotated[
+    str, StringConstraints(min_length=32, max_length=128, pattern=ROW_KEY_PATTERN)
 ]
 
 
@@ -59,10 +57,10 @@ class WireModel(Model):
 
 
 class McpRequestRow(WireModel):
-    row_id: OpaqueRowId = Field(alias="rowId")
-    country: str = Field(max_length=2, pattern=COUNTRY_PATTERN)
-    region: str = Field(default="", max_length=16, pattern=REGION_PATTERN)
-    city: str = Field(default="", max_length=200, pattern=CITY_PATTERN)
+    row_key: OpaqueRowKey = Field(alias="rowKey")
+    country_code: str = Field(alias="countryCode", max_length=16)
+    region_code: str = Field(default="", alias="regionCode", max_length=16)
+    city_name: str = Field(default="", alias="cityName", max_length=200)
     search_mode: McpSearchMode = Field(default=McpSearchMode.AUTO, alias="searchMode")
 
 
@@ -70,44 +68,44 @@ class McpRequestBatch(WireModel):
     rows: list[McpRequestRow] = Field(min_length=1)
 
     @model_validator(mode="after")
-    def validate_unique_row_ids(self) -> McpRequestBatch:
-        ids = [row.row_id for row in self.rows]
-        if len(ids) != len(set(ids)):
-            raise ValueError("rowId values must be unique within a request batch")
+    def validate_unique_row_keys(self) -> McpRequestBatch:
+        keys = [row.row_key for row in self.rows]
+        if len(keys) != len(set(keys)):
+            raise ValueError("rowKey values must be unique within a request batch")
         return self
 
 
 class McpMappingTarget(WireModel):
-    representative_row_id: OpaqueRowId = Field(alias="representativeRowId")
+    representative_row_key: OpaqueRowKey = Field(alias="representativeRowKey")
     target_source_row_ids: list[str] = Field(alias="targetSourceRowIds", min_length=1)
-    target_opaque_row_ids: list[OpaqueRowId] = Field(alias="targetOpaqueRowIds", min_length=1)
+    target_opaque_row_keys: list[OpaqueRowKey] = Field(alias="targetOpaqueRowKeys", min_length=1)
 
     @model_validator(mode="after")
     def validate_targets(self) -> McpMappingTarget:
-        if len(self.target_source_row_ids) != len(self.target_opaque_row_ids):
+        if len(self.target_source_row_ids) != len(self.target_opaque_row_keys):
             raise ValueError("source and opaque target lists must have equal lengths")
         if len(self.target_source_row_ids) != len(set(self.target_source_row_ids)):
             raise ValueError("target source row IDs must be unique")
-        if len(self.target_opaque_row_ids) != len(set(self.target_opaque_row_ids)):
-            raise ValueError("target opaque row IDs must be unique")
-        if self.representative_row_id != self.target_opaque_row_ids[0]:
-            raise ValueError("representativeRowId must be the first target opaque row ID")
+        if len(self.target_opaque_row_keys) != len(set(self.target_opaque_row_keys)):
+            raise ValueError("target opaque row keys must be unique")
+        if self.representative_row_key != self.target_opaque_row_keys[0]:
+            raise ValueError("representativeRowKey must be the first target opaque row key")
         return self
 
 
 class McpMappingBatch(WireModel):
     batch_number: int = Field(alias="batchNumber", ge=1)
     request_sha256: str = Field(alias="requestSha256", pattern="^[0-9a-f]{64}$")
-    representative_row_ids: list[OpaqueRowId] = Field(alias="representativeRowIds", min_length=1)
+    representative_row_keys: list[OpaqueRowKey] = Field(alias="representativeRowKeys", min_length=1)
     targets: list[McpMappingTarget] = Field(min_length=1)
 
     @model_validator(mode="after")
     def validate_representatives(self) -> McpMappingBatch:
-        target_representatives = [target.representative_row_id for target in self.targets]
-        if self.representative_row_ids != target_representatives:
-            raise ValueError("representativeRowIds must match targets in request order")
-        if len(self.representative_row_ids) != len(set(self.representative_row_ids)):
-            raise ValueError("representative row IDs must be unique")
+        target_representatives = [target.representative_row_key for target in self.targets]
+        if self.representative_row_keys != target_representatives:
+            raise ValueError("representativeRowKeys must match targets in request order")
+        if len(self.representative_row_keys) != len(set(self.representative_row_keys)):
+            raise ValueError("representative row keys must be unique")
         return self
 
 
@@ -125,26 +123,26 @@ class McpRequestMapping(WireModel):
         if [batch.batch_number for batch in self.batches] != list(range(1, len(self.batches) + 1)):
             raise ValueError("mapping batch numbers must be contiguous from one")
         representatives = [
-            row_id for batch in self.batches for row_id in batch.representative_row_ids
+            row_key for batch in self.batches for row_key in batch.representative_row_keys
         ]
         if len(representatives) != len(set(representatives)):
-            raise ValueError("representative row IDs must be globally unique")
+            raise ValueError("representative row keys must be globally unique")
         target_source_ids = [
             row_id
             for batch in self.batches
             for target in batch.targets
             for row_id in target.target_source_row_ids
         ]
-        target_opaque_ids = [
-            row_id
+        target_opaque_keys = [
+            row_key
             for batch in self.batches
             for target in batch.targets
-            for row_id in target.target_opaque_row_ids
+            for row_key in target.target_opaque_row_keys
         ]
         if len(target_source_ids) != len(set(target_source_ids)):
             raise ValueError("target source row coverage must be unique")
-        if len(target_opaque_ids) != len(set(target_opaque_ids)):
-            raise ValueError("target opaque row coverage must be unique")
+        if len(target_opaque_keys) != len(set(target_opaque_keys)):
+            raise ValueError("target opaque row-key coverage must be unique")
         if self.integrity_sha256 != _mapping_integrity_digest(self):
             raise ValueError("mapping integrity digest does not match its contents")
         return self
@@ -184,7 +182,7 @@ _STATUS_CODES: dict[McpRowStatus, set[McpResultCode]] = {
     McpRowStatus.DO_NOT_GEOLOCATE: {McpResultCode.DO_NOT_GEOLOCATE},
     McpRowStatus.NO_MATCH: {McpResultCode.NO_MATCH},
     McpRowStatus.INVALID_INPUT: {
-        McpResultCode.INVALID_ROW_ID,
+        McpResultCode.INVALID_ROW_KEY,
         McpResultCode.INVALID_COUNTRY_CODE,
         McpResultCode.INVALID_REGION_CODE,
         McpResultCode.INVALID_CITY_NAME,
@@ -195,7 +193,7 @@ _STATUS_CODES: dict[McpRowStatus, set[McpResultCode]] = {
 
 
 class McpResponseRow(WireModel):
-    row_id: OpaqueRowId = Field(alias="rowId")
+    row_key: OpaqueRowKey = Field(alias="rowKey")
     status: McpRowStatus
     code: McpResultCode
     message: str = Field(min_length=1)
@@ -233,9 +231,9 @@ class McpResponseBatch(WireModel):
     def validate_batch_invariants(self) -> McpResponseBatch:
         if len(self.results) > self.batch_limit:
             raise ValueError("results exceed batchLimit")
-        ids = [result.row_id for result in self.results]
-        if len(ids) != len(set(ids)):
-            raise ValueError("result rowId values must be unique")
+        keys = [result.row_key for result in self.results]
+        if len(keys) != len(set(keys)):
+            raise ValueError("result rowKey values must be unique")
         statuses = Counter(result.status for result in self.results)
         expected = {
             "total": len(self.results),
@@ -251,8 +249,8 @@ class McpResponseBatch(WireModel):
         return self
 
 
-def opaque_row_id(analysis: Analysis, row: RowRecord) -> str:
-    """Derive a stable non-reversible MCP identifier without location-only hashing."""
+def opaque_row_key(analysis: Analysis, row: RowRecord) -> str:
+    """Derive a deterministic privacy-safe MCP rowKey for a source row."""
     material = f"fastah-geofeed-mcp-row-v1\0{analysis.analysis_id}\0{row.id}".encode()
     return f"fq-{hashlib.sha256(material).hexdigest()[:32]}"
 
@@ -308,21 +306,21 @@ def export_request_exchange(
     requests: list[McpRequestRow] = []
     targets: list[McpMappingTarget] = []
     for (country, region, city, _), rows in groups.items():
-        representative_id = opaque_row_id(analysis, rows[0])
+        representative_key = opaque_row_key(analysis, rows[0])
         requests.append(
             McpRequestRow(
-                rowId=representative_id,
-                country=country,
-                region=region,
-                city=city,
+                rowKey=representative_key,
+                countryCode=country,
+                regionCode=region,
+                cityName=city,
                 searchMode=search_mode,
             )
         )
         targets.append(
             McpMappingTarget(
-                representativeRowId=representative_id,
+                representativeRowKey=representative_key,
                 targetSourceRowIds=[row.id for row in rows],
-                targetOpaqueRowIds=[opaque_row_id(analysis, row) for row in rows],
+                targetOpaqueRowKeys=[opaque_row_key(analysis, row) for row in rows],
             )
         )
 
@@ -336,7 +334,7 @@ def export_request_exchange(
             McpMappingBatch(
                 batchNumber=len(batches),
                 requestSha256=_request_digest(batch),
-                representativeRowIds=[target.representative_row_id for target in batch_targets],
+                representativeRowKeys=[target.representative_row_key for target in batch_targets],
                 targets=batch_targets,
             )
         )
@@ -434,7 +432,7 @@ def import_response_batches(
 
     eligible = _eligible_rows(analysis)
     row_by_source = {row.id: row for row in eligible}
-    expected_opaque_ids = [opaque_row_id(analysis, row) for row in eligible]
+    expected_opaque_keys = [opaque_row_key(analysis, row) for row in eligible]
     _, expected_mapping = export_request_exchange(
         analysis, server_advertised_batch_limit, search_mode
     )
@@ -443,51 +441,51 @@ def import_response_batches(
             "mapping does not match this analysis, search mode, limit, or exported requests"
         )
     flattened = list(_response_rows(responses))
-    actual_ids = [result.row_id for _, result in flattened]
-    if len(actual_ids) != len(set(actual_ids)):
-        raise McpExchangeError("captured responses contain duplicate rowId values")
+    actual_keys = [result.row_key for _, result in flattened]
+    if len(actual_keys) != len(set(actual_keys)):
+        raise McpExchangeError("captured responses contain duplicate rowKey values")
     expected_representatives = [
-        row_id for batch in mapping.batches for row_id in batch.representative_row_ids
+        row_key for batch in mapping.batches for row_key in batch.representative_row_keys
     ]
-    unknown = sorted(set(actual_ids) - set(expected_representatives))
+    unknown = sorted(set(actual_keys) - set(expected_representatives))
     if unknown:
         raise McpExchangeError(
-            f"captured response contains unknown representative rowId {unknown[0]}"
+            f"captured response contains unknown representative rowKey {unknown[0]}"
         )
     if len(responses) != len(mapping.batches):
         raise McpExchangeError("captured responses must correspond to every exported request batch")
     for response, batch_mapping in zip(responses, mapping.batches, strict=True):
-        if [result.row_id for result in response.results] != batch_mapping.representative_row_ids:
+        if [result.row_key for result in response.results] != batch_mapping.representative_row_keys:
             raise McpExchangeError(
                 "captured response row order must match its exported request batch"
             )
-    if actual_ids != expected_representatives:
+    if actual_keys != expected_representatives:
         raise McpExchangeError("captured results must cover representative rows once in order")
 
     expanded: list[tuple[McpResponseBatch, McpResponseRow, RowRecord, str, str, str]] = []
     for response, batch_mapping in zip(responses, mapping.batches, strict=True):
         for result, target_mapping in zip(response.results, batch_mapping.targets, strict=True):
-            for source_id, opaque_id in zip(
+            for source_id, opaque_key in zip(
                 target_mapping.target_source_row_ids,
-                target_mapping.target_opaque_row_ids,
+                target_mapping.target_opaque_row_keys,
                 strict=True,
             ):
                 target = row_by_source.get(source_id)
-                if target is None or opaque_row_id(analysis, target) != opaque_id:
+                if target is None or opaque_row_key(analysis, target) != opaque_key:
                     raise McpExchangeError("mapping target is unknown or stale")
                 expanded.append(
                     (
                         response,
                         result,
                         target,
-                        opaque_id,
-                        target_mapping.representative_row_id,
+                        opaque_key,
+                        target_mapping.representative_row_key,
                         batch_mapping.request_sha256,
                     )
                 )
     source_order = {row.id: index for index, row in enumerate(eligible)}
     expanded.sort(key=lambda item: source_order[item[2].id])
-    if [item[3] for item in expanded] != expected_opaque_ids:
+    if [item[3] for item in expanded] != expected_opaque_keys:
         raise McpExchangeError(
             "mapping must cover every eligible target exactly once in source order"
         )
@@ -500,15 +498,15 @@ def import_response_batches(
         for observation in analysis.enrichment.mcp_observations
     }
     if existing:
-        if set(existing) != set(expected_opaque_ids):
+        if set(existing) != set(expected_opaque_keys):
             raise McpExchangeError("analysis already contains a different MCP import")
-        for response, result, _, opaque_id, representative_id, request_digest in expanded:
-            observation = existing[opaque_id]
+        for response, result, _, opaque_key, representative_key, request_digest in expanded:
+            observation = existing[opaque_key]
             if (
                 observation.search_mode != search_mode
                 or observation.contract_version != response.contract_version
                 or observation.server_batch_limit != response.batch_limit
-                or observation.representative_opaque_row_id != representative_id
+                or observation.representative_opaque_row_id != representative_key
                 or observation.request_sha256 != request_digest
                 or observation.status != result.status
                 or observation.code != result.code
@@ -526,7 +524,7 @@ def import_response_batches(
     enriched.configuration.mcp = McpConfigurationSummary(
         server_advertised_batch_limit=server_advertised_batch_limit
     )
-    for response, result, target, opaque_id, representative_id, request_digest in expanded:
+    for response, result, target, opaque_key, representative_key, request_digest in expanded:
         response_digest = response_digests[id(response)]
         evidence = Evidence(
             id=f"evidence-{len(enriched.evidence) + 1:06d}",
@@ -535,8 +533,8 @@ def import_response_batches(
             observed_at=enriched.created_at,
             target_ids=[target.id],
             values={
-                "opaque_row_id": opaque_id,
-                "representative_opaque_row_id": representative_id,
+                "opaque_row_id": opaque_key,
+                "representative_opaque_row_id": representative_key,
                 "request_sha256": request_digest,
                 "search_mode": search_mode.value,
                 "contract_version": response.contract_version,
@@ -553,8 +551,8 @@ def import_response_batches(
         observation = McpObservation(
             id=f"mcp-{len(enriched.enrichment.mcp_observations) + 1:06d}",
             target_row_id=target.id,
-            opaque_row_id=opaque_id,
-            representative_opaque_row_id=representative_id,
+            opaque_row_id=opaque_key,
+            representative_opaque_row_id=representative_key,
             request_sha256=request_digest,
             search_mode=search_mode,
             contract_version=response.contract_version,

--- a/tuning-geofeeds/package/src/geofeed_quality/models.py
+++ b/tuning-geofeeds/package/src/geofeed_quality/models.py
@@ -1,3 +1,4 @@
+# Copyright 2026 Fastah Inc.
 """Pydantic source of truth for analysis IR v0.4.0."""
 
 from __future__ import annotations
@@ -122,7 +123,7 @@ class McpResultCode(StrEnum):
     MATCH_FOUND = "MATCH_FOUND"
     DO_NOT_GEOLOCATE = "DO_NOT_GEOLOCATE"
     NO_MATCH = "NO_MATCH"
-    INVALID_ROW_ID = "INVALID_ROW_ID"
+    INVALID_ROW_KEY = "INVALID_ROW_KEY"
     INVALID_COUNTRY_CODE = "INVALID_COUNTRY_CODE"
     INVALID_REGION_CODE = "INVALID_REGION_CODE"
     INVALID_CITY_NAME = "INVALID_CITY_NAME"

--- a/tuning-geofeeds/package/src/geofeed_quality/rdap.py
+++ b/tuning-geofeeds/package/src/geofeed_quality/rdap.py
@@ -1,3 +1,4 @@
+# Copyright 2026 Fastah Inc.
 """Privacy-minimizing authoritative RDAP lookup and publisher assessment."""
 
 from __future__ import annotations
@@ -232,7 +233,7 @@ class BootstrapRegistry:
                 for prefix in prefixes:
                     try:
                         network = ipaddress.ip_network(prefix, strict=True)
-                    except (TypeError, ValueError):
+                    except TypeError, ValueError:
                         continue
                     if network.version == version:
                         services.append(
@@ -294,7 +295,7 @@ def _retry_after(value: str | None, now: datetime) -> int | None:
     except ValueError:
         try:
             parsed = parsedate_to_datetime(value)
-        except (TypeError, ValueError, OverflowError):
+        except TypeError, ValueError, OverflowError:
             return None
         if parsed.tzinfo is None:
             parsed = parsed.replace(tzinfo=UTC)
@@ -623,7 +624,7 @@ class AuthoritativeRdapClient:
                 retryable=error.retryable,
                 failure_code=error.code,
             )
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             result = RdapLookupResult(
                 requested_prefix=prefix,
                 queried_at=queried_at,
@@ -810,7 +811,7 @@ def enrich_analysis(
                 assessment, explanation, matched, conflicting = _assessment(
                     normalized_profile, result.entities
                 )
-            except (TypeError, ValueError):
+            except TypeError, ValueError:
                 result = replace(
                     result,
                     retryable=False,

--- a/tuning-geofeeds/package/src/geofeed_quality/renderer.py
+++ b/tuning-geofeeds/package/src/geofeed_quality/renderer.py
@@ -1,3 +1,4 @@
+# Copyright 2026 Fastah Inc.
 """Markdown projection of an already serialized and validated analysis IR."""
 
 from __future__ import annotations

--- a/tuning-geofeeds/package/src/geofeed_quality/runtime.py
+++ b/tuning-geofeeds/package/src/geofeed_quality/runtime.py
@@ -1,3 +1,4 @@
+# Copyright 2026 Fastah Inc.
 """Portable analyzer runtime compatibility guard."""
 
 from __future__ import annotations

--- a/tuning-geofeeds/package/src/geofeed_quality/schema.py
+++ b/tuning-geofeeds/package/src/geofeed_quality/schema.py
@@ -1,3 +1,4 @@
+# Copyright 2026 Fastah Inc.
 """Generate and validate the committed analysis schema."""
 
 from __future__ import annotations

--- a/tuning-geofeeds/package/tests/fixtures/mcp-response-v1.json
+++ b/tuning-geofeeds/package/tests/fixtures/mcp-response-v1.json
@@ -12,7 +12,7 @@
   },
   "results": [
     {
-      "rowId": "fq-e060519da065a34770c5e16dd0a1bdeb",
+      "rowKey": "fq-e060519da065a34770c5e16dd0a1bdeb",
       "status": "matched",
       "code": "MATCH_FOUND",
       "message": "Place matches found, ordered best-first.",
@@ -38,7 +38,7 @@
       ]
     },
     {
-      "rowId": "fq-2e905fb3c8238fce769626af308b4715",
+      "rowKey": "fq-2e905fb3c8238fce769626af308b4715",
       "status": "backend_unavailable",
       "code": "BACKEND_UNAVAILABLE",
       "message": "The place-search backend is temporarily unavailable. Retry this row later.",
@@ -46,7 +46,7 @@
       "matches": []
     },
     {
-      "rowId": "fq-f3c1092fa608a325c2f9aec1b49e5f1d",
+      "rowKey": "fq-f3c1092fa608a325c2f9aec1b49e5f1d",
       "status": "do_not_geolocate",
       "code": "DO_NOT_GEOLOCATE",
       "message": "The country is empty or ZZ, so this row must not be geolocated. No place lookup was sent.",

--- a/tuning-geofeeds/package/tests/test_analyzer.py
+++ b/tuning-geofeeds/package/tests/test_analyzer.py
@@ -1,3 +1,4 @@
+# Copyright 2026 Fastah Inc.
 from __future__ import annotations
 
 import ipaddress

--- a/tuning-geofeeds/package/tests/test_cli.py
+++ b/tuning-geofeeds/package/tests/test_cli.py
@@ -1,3 +1,4 @@
+# Copyright 2026 Fastah Inc.
 from __future__ import annotations
 
 import json

--- a/tuning-geofeeds/package/tests/test_corrections.py
+++ b/tuning-geofeeds/package/tests/test_corrections.py
@@ -1,3 +1,4 @@
+# Copyright 2026 Fastah Inc.
 from __future__ import annotations
 
 import copy
@@ -254,7 +255,8 @@ def test_mcp_best_match_is_advisory_and_failures_never_propose(tmp_path: Path) -
 
     request = request_document(export_request_batches(proposed, 1_000)[0])
     assert all(
-        set(row) <= {"rowId", "country", "region", "city", "searchMode"} for row in request["rows"]
+        set(row) <= {"rowKey", "countryCode", "regionCode", "cityName", "searchMode"}
+        for row in request["rows"]
     )
     encoded = json.dumps(request)
     assert "proposal-" not in encoded and "corrections" not in encoded and "rdap" not in encoded

--- a/tuning-geofeeds/package/tests/test_mcp_exchange.py
+++ b/tuning-geofeeds/package/tests/test_mcp_exchange.py
@@ -1,3 +1,4 @@
+# Copyright 2026 Fastah Inc.
 from __future__ import annotations
 
 import copy
@@ -16,7 +17,7 @@ from geofeed_quality.mcp_exchange import (
     McpResponseBatch,
     export_request_batches,
     export_request_exchange,
-    opaque_row_id,
+    opaque_row_key,
     request_document,
 )
 from geofeed_quality.mcp_exchange import (
@@ -38,6 +39,10 @@ from geofeed_quality.schema import (
 )
 
 FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _wire_row_key(index: int) -> str:
+    return f"test-row-key-{index:020d}"
 
 
 def _fixture_response() -> dict[str, Any]:
@@ -96,16 +101,16 @@ def test_export_deduplicates_exact_tuples_in_first_seen_order_and_maps_targets(
     )
     analysis = analyze_file(feed)
     batches, mapping = export_request_exchange(analysis, 2)
-    assert [[row.city for row in batch.rows] for batch in batches] == [
+    assert [[row.city_name for row in batch.rows] for batch in batches] == [
         ["Mountain View", "New York"],
         ["Austin"],
     ]
     first = mapping.batches[0].targets[0]
     assert first.target_source_row_ids == ["row-000001", "row-000003", "row-000005"]
-    assert first.target_opaque_row_ids == [
-        opaque_row_id(analysis, analysis.rows[index]) for index in (0, 2, 4)
+    assert first.target_opaque_row_keys == [
+        opaque_row_key(analysis, analysis.rows[index]) for index in (0, 2, 4)
     ]
-    assert mapping.batches[0].representative_row_ids[0] == first.target_opaque_row_ids[0]
+    assert mapping.batches[0].representative_row_keys[0] == first.target_opaque_row_keys[0]
     encoded_requests = json.dumps([request_document(batch) for batch in batches])
     encoded_mapping = mapping.model_dump_json(by_alias=True)
     for prefix in ("8.8.8.0/24", "1.1.1.0/24", "9.9.9.0/24"):
@@ -144,7 +149,7 @@ def test_every_status_fans_out_to_unique_exactly_once_observations(
     batches, mapping = export_request_exchange(analysis, 1_000)
     result = copy.deepcopy(_fixture_response()["results"][0])
     result.update(
-        rowId=batches[0].rows[0].row_id,
+        rowKey=batches[0].rows[0].row_key,
         status=status,
         code=code,
         retryable=retryable,
@@ -189,17 +194,17 @@ def test_import_rejects_tampered_and_stale_mapping(tmp_path: Path) -> None:
         _import_response_batches(other, [_fixture_response()], mapping, 1_000)
 
 
-def test_opaque_ids_are_deterministic_unique_and_not_location_only() -> None:
+def test_opaque_row_keys_are_deterministic_unique_and_not_location_only() -> None:
     first = analyze_file(FIXTURES / "valid.csv")
     second = first.model_copy(deep=True)
     eligible = [row for row in first.rows if row.kind == RowKind.DATA]
-    ids = [opaque_row_id(first, row) for row in eligible]
-    assert ids == [opaque_row_id(second, row) for row in eligible]
+    ids = [opaque_row_key(first, row) for row in eligible]
+    assert ids == [opaque_row_key(second, row) for row in eligible]
     assert len(ids) == len(set(ids))
     assert all(value.startswith("fq-") and len(value) == 35 for value in ids)
 
     duplicated_location = eligible[0].model_copy(deep=True, update={"id": "row-999999"})
-    assert opaque_row_id(first, eligible[0]) != opaque_row_id(first, duplicated_location)
+    assert opaque_row_key(first, eligible[0]) != opaque_row_key(first, duplicated_location)
 
 
 def test_export_is_a_mechanical_privacy_allowlist() -> None:
@@ -209,7 +214,7 @@ def test_export_is_a_mechanical_privacy_allowlist() -> None:
     )
     document = request_document(export_request_batches(analysis, 1_000)[0])
     assert set(document) == {"rows"}
-    allowed = {"rowId", "country", "region", "city", "searchMode"}
+    allowed = {"rowKey", "countryCode", "regionCode", "cityName", "searchMode"}
     assert all(set(row) <= allowed for row in document["rows"])
     encoded = json.dumps(document)
     for prohibited in (
@@ -231,14 +236,14 @@ def test_empty_and_zz_rows_receive_normalized_dng_outcomes_without_mutation(
     feed.write_text("8.8.8.0/24,,,,\n1.1.1.0/24,zz,,,\n", encoding="utf-8")
     analysis = analyze_file(feed)
     batch = export_request_batches(analysis, 1_000)[0]
-    assert [row.country for row in batch.rows] == ["", "ZZ"]
+    assert [row.country_code for row in batch.rows] == ["", "ZZ"]
     assert all(row.state == RowState.VALID_DO_NOT_GEOLOCATE for row in analysis.rows)
 
     do_not_geolocate = cast(dict[str, Any], _fixture_response()["results"][2])
     results: list[dict[str, Any]] = []
     for request in batch.rows:
         result = copy.deepcopy(do_not_geolocate)
-        result["rowId"] = request.row_id
+        result["rowKey"] = request.row_key
         results.append(result)
     response: dict[str, Any] = {
         "contractVersion": "1.0",
@@ -274,10 +279,10 @@ def test_wire_schemas_are_closed_draft_2020_12_and_drift_checked() -> None:
     assert request_schema["additionalProperties"] is False
     assert response_schema["additionalProperties"] is False
     assert set(request_schema["$defs"]["McpRequestRow"]["properties"]) == {
-        "rowId",
-        "country",
-        "region",
-        "city",
+        "rowKey",
+        "countryCode",
+        "regionCode",
+        "cityName",
         "searchMode",
     }
 
@@ -359,16 +364,16 @@ def test_import_rejects_contract_invariant_failures(
         import_response_batches(analysis, [response], 1_000)
 
 
-def test_import_rejects_unknown_duplicate_missing_and_reordered_ids() -> None:
+def test_import_rejects_unknown_duplicate_missing_and_reordered_keys() -> None:
     analysis = analyze_file(FIXTURES / "valid.csv")
 
     unknown = _fixture_response()
-    unknown["results"][0]["rowId"] = "unknown-row-id"
-    with pytest.raises(McpExchangeError, match="unknown representative rowId"):
+    unknown["results"][0]["rowKey"] = _wire_row_key(999)
+    with pytest.raises(McpExchangeError, match="unknown representative rowKey"):
         import_response_batches(analysis, [unknown], 1_000)
 
     duplicate = _fixture_response()
-    duplicate["results"][1]["rowId"] = duplicate["results"][0]["rowId"]
+    duplicate["results"][1]["rowKey"] = duplicate["results"][0]["rowKey"]
     with pytest.raises(McpExchangeError, match=r"unique|duplicate"):
         import_response_batches(analysis, [duplicate], 1_000)
 
@@ -390,7 +395,7 @@ def test_import_rejects_unknown_duplicate_missing_and_reordered_ids() -> None:
 def test_all_statuses_validate_with_ordered_mixed_partial_results() -> None:
     rows = [
         {
-            "rowId": f"row-000{index}",
+            "rowKey": _wire_row_key(index),
             "status": status,
             "code": code,
             "message": "safe",
@@ -408,7 +413,7 @@ def test_all_statuses_validate_with_ordered_mixed_partial_results() -> None:
         )
     ]
     matched = copy.deepcopy(_fixture_response()["results"][0])
-    matched["rowId"] = "row-0005"
+    matched["rowKey"] = _wire_row_key(5)
     rows.append(matched)
     response = McpResponseBatch.model_validate(
         {
@@ -435,14 +440,14 @@ def test_all_statuses_validate_with_ordered_mixed_partial_results() -> None:
     ]
 
 
-def test_request_model_rejects_unknown_fields_and_duplicate_ids() -> None:
+def test_request_model_rejects_unknown_fields_and_duplicate_row_keys() -> None:
     with pytest.raises(ValueError):
         McpRequestBatch.model_validate(
             {
                 "rows": [
                     {
-                        "rowId": "row-0001",
-                        "country": "US",
+                        "rowKey": _wire_row_key(1),
+                        "countryCode": "US",
                         "searchMode": "auto",
                         "prefix": "8.8.8.0/24",
                     }
@@ -453,8 +458,16 @@ def test_request_model_rejects_unknown_fields_and_duplicate_ids() -> None:
         McpRequestBatch.model_validate(
             {
                 "rows": [
-                    {"rowId": "row-0001", "country": "US", "searchMode": "auto"},
-                    {"rowId": "row-0001", "country": "GB", "searchMode": "auto"},
+                    {
+                        "rowKey": _wire_row_key(1),
+                        "countryCode": "US",
+                        "searchMode": "auto",
+                    },
+                    {
+                        "rowKey": _wire_row_key(1),
+                        "countryCode": "GB",
+                        "searchMode": "auto",
+                    },
                 ]
             }
         )

--- a/tuning-geofeeds/package/tests/test_public_packaging.py
+++ b/tuning-geofeeds/package/tests/test_public_packaging.py
@@ -1,3 +1,4 @@
+# Copyright 2026 Fastah Inc.
 from __future__ import annotations
 
 import importlib.util
@@ -10,9 +11,7 @@ from typing import Any, cast
 
 import pytest
 
-APACHE_2_LICENSE_SHA256 = (
-    "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30"
-)
+APACHE_2_LICENSE_SHA256 = "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30"
 
 
 def _packager() -> ModuleType:
@@ -34,12 +33,7 @@ def _packager() -> ModuleType:
 
 
 def _config() -> dict[str, Any]:
-    path = (
-        Path(__file__).parents[1]
-        / "tuning-geofeeds"
-        / "packaging"
-        / "release.json"
-    )
+    path = Path(__file__).parents[1] / "tuning-geofeeds" / "packaging" / "release.json"
     value = json.loads(path.read_text(encoding="utf-8"))
     assert isinstance(value, dict)
     return cast(dict[str, Any], value)
@@ -70,9 +64,13 @@ def test_public_root_is_generated_from_canonical_metadata(tmp_path: Path) -> Non
         "sha256": APACHE_2_LICENSE_SHA256,
         "source": "tuning-geofeeds/packaging/public/LICENSE",
     }
-    assert (tmp_path / "LICENSE").read_text(encoding="utf-8").startswith(
-        "\n                                 Apache License\n"
-        "                           Version 2.0, January 2004\n"
+    assert (
+        (tmp_path / "LICENSE")
+        .read_text(encoding="utf-8")
+        .startswith(
+            "\n                                 Apache License\n"
+            "                           Version 2.0, January 2004\n"
+        )
     )
     packager.release_check._validate_files(tmp_path)
 
@@ -133,11 +131,7 @@ def test_public_root_rejects_outdated_global_mcp_discovery(tmp_path: Path) -> No
 def test_canonical_public_license_exists_with_exact_apache_2_content() -> None:
     packager = _packager()
     license_path = (
-        Path(__file__).parents[1]
-        / "tuning-geofeeds"
-        / "packaging"
-        / "public"
-        / "LICENSE"
+        Path(__file__).parents[1] / "tuning-geofeeds" / "packaging" / "public" / "LICENSE"
     )
 
     assert license_path.is_file()
@@ -159,3 +153,18 @@ def test_release_copy_excludes_generated_egg_info(tmp_path: Path) -> None:
 
     assert (target / "package" / "module.py").is_file()
     assert not (target / "package" / "example.egg-info").exists()
+
+
+def test_release_validation_requires_exact_source_notice(tmp_path: Path) -> None:
+    packager = _packager()
+    plain = tmp_path / "plain.py"
+    executable = tmp_path / "executable.py"
+    notice = "# Copyright 2026 Fastah Inc."
+    plain.write_text(f"{notice}\nvalue = 1\n", encoding="utf-8")
+    executable.write_text(f"#!/usr/bin/env python3\n{notice}\nvalue = 1\n", encoding="utf-8")
+
+    packager.release_check._validate_files(tmp_path)
+
+    plain.write_text("value = 1\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="missing exact copyright notice"):
+        packager.release_check._validate_files(tmp_path)

--- a/tuning-geofeeds/package/tests/test_public_sample_fixture.py
+++ b/tuning-geofeeds/package/tests/test_public_sample_fixture.py
@@ -1,3 +1,4 @@
+# Copyright 2026 Fastah Inc.
 from __future__ import annotations
 
 import importlib.util

--- a/tuning-geofeeds/package/tests/test_rdap.py
+++ b/tuning-geofeeds/package/tests/test_rdap.py
@@ -1,3 +1,4 @@
+# Copyright 2026 Fastah Inc.
 from __future__ import annotations
 
 import json

--- a/tuning-geofeeds/package/tests/test_runtime.py
+++ b/tuning-geofeeds/package/tests/test_runtime.py
@@ -1,3 +1,4 @@
+# Copyright 2026 Fastah Inc.
 from __future__ import annotations
 
 import subprocess
@@ -42,9 +43,7 @@ def test_pycountry_dependency_floor_and_installed_version() -> None:
 
 
 def test_agent_launcher_rejects_prerelease_before_importing_pydantic() -> None:
-    launcher = (
-        Path(__file__).parents[1] / "tuning-geofeeds" / "scripts" / "geofeed_cli.py"
-    )
+    launcher = Path(__file__).parents[1] / "tuning-geofeeds" / "scripts" / "geofeed_cli.py"
     script = textwrap.dedent(
         f"""
         import importlib.util
@@ -79,9 +78,7 @@ def test_agent_launcher_rejects_prerelease_before_importing_pydantic() -> None:
 
 
 def test_agent_launcher_help_exposes_examples_and_exit_meanings() -> None:
-    launcher = (
-        Path(__file__).parents[1] / "tuning-geofeeds" / "scripts" / "geofeed_cli.py"
-    )
+    launcher = Path(__file__).parents[1] / "tuning-geofeeds" / "scripts" / "geofeed_cli.py"
     completed = subprocess.run(
         [sys.executable, str(launcher), "--help"],
         text=True,

--- a/tuning-geofeeds/package/tests/test_schema_and_renderer.py
+++ b/tuning-geofeeds/package/tests/test_schema_and_renderer.py
@@ -1,3 +1,4 @@
+# Copyright 2026 Fastah Inc.
 from __future__ import annotations
 
 import copy

--- a/tuning-geofeeds/package/tests/test_visual_renderers.py
+++ b/tuning-geofeeds/package/tests/test_visual_renderers.py
@@ -1,3 +1,4 @@
+# Copyright 2026 Fastah Inc.
 from __future__ import annotations
 
 import json

--- a/tuning-geofeeds/scripts/evaluate.py
+++ b/tuning-geofeeds/scripts/evaluate.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# Copyright 2026 Fastah Inc.
 """Run deterministic skill eval fixtures and emit evidence-bearing grades."""
 
 from __future__ import annotations
@@ -150,7 +151,7 @@ def _mcp(runner: Runner) -> list[Result]:
     runner.render_all(enriched, "enriched")
     document = _load(enriched)
     statuses = [item["status"] for item in document["enrichment"]["mcp_observations"]]
-    allowed = {"rowId", "country", "region", "city", "searchMode"}
+    allowed = {"rowKey", "countryCode", "regionCode", "cityName", "searchMode"}
     return [
         (
             set(request) == {"rows"} and all(set(row) <= allowed for row in request["rows"]),

--- a/tuning-geofeeds/scripts/geofeed_cli.py
+++ b/tuning-geofeeds/scripts/geofeed_cli.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# Copyright 2026 Fastah Inc.
 """Run the bundled analyzer without relying on the current working directory."""
 
 from __future__ import annotations

--- a/tuning-geofeeds/scripts/release_check.py
+++ b/tuning-geofeeds/scripts/release_check.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# Copyright 2026 Fastah Inc.
 """Build and verify a deterministic private portable release layout."""
 
 from __future__ import annotations
@@ -33,6 +34,7 @@ SECRET_PATTERNS = {
     "Slack token": re.compile(rb"xox[baprs]-[A-Za-z0-9-]{20,}"),
 }
 MARKDOWN_LINK = re.compile(r"\[[^]]*\]\(([^)]+)\)")
+COPYRIGHT_NOTICE = "# Copyright 2026 Fastah Inc."
 
 
 def _skill_root() -> Path:
@@ -193,6 +195,13 @@ def _validate_files(root: Path) -> None:
             content.decode("utf-8")
         except UnicodeDecodeError as error:
             raise ValueError(f"required text file is not UTF-8: {relative}") from error
+        if path.suffix == ".py":
+            lines = content.decode("utf-8").splitlines()
+            notice_index = 1 if lines and lines[0].startswith("#!") else 0
+            if len(lines) <= notice_index or lines[notice_index] != COPYRIGHT_NOTICE:
+                raise ValueError(
+                    f"published Python source missing exact copyright notice: {relative}"
+                )
     prohibited = (".env", "__pycache__", ".pyc", "credentials", "node_modules", ".venv")
     for path in root.rglob("*"):
         if any(part in prohibited for part in path.relative_to(root).parts):
@@ -336,7 +345,9 @@ def main() -> int:
             with tempfile.TemporaryDirectory(prefix="tuning-geofeeds-release-") as temporary:
                 target = Path(temporary)
                 first = _verify(_build(target))
-                with tempfile.TemporaryDirectory(prefix="tuning-geofeeds-release-2-") as second_temp:
+                with tempfile.TemporaryDirectory(
+                    prefix="tuning-geofeeds-release-2-"
+                ) as second_temp:
                     second = _verify(_build(Path(second_temp)))
                 if first != second:
                     raise ValueError("release layout is not deterministic")

--- a/tuning-geofeeds/scripts/verify_public_sample.py
+++ b/tuning-geofeeds/scripts/verify_public_sample.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# Copyright 2026 Fastah Inc.
 """Build or verify the deterministic public geofeed evaluation sample."""
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- align public MCP request/response/mapping files with the live contract: `rowKey`, `countryCode`, `regionCode`, `cityName`, and `searchMode`
- preserve deterministic first-seen deduplication, integrity-bound local mapping, response ordering, partial-failure behavior, and fanout
- update schemas, fixtures, tests, evals, and operator guidance
- add `Copyright 2026 Fastah Inc.` to all 27 published Python source files and enforce it in release validation

Generated exactly from private monorepo source `c00ba4aa716afc2dd9b540bdbc6be8b5e19b9569` after merged PR #1806.

## Verification
- canonical package/public-stage checks passed under Python 3.14.7 final
- public tree matches all 67 generated files byte-for-byte
- manifest SHA-256: `9e6359c970346cc119d902918a57430f89812947fcdbb9f6629dbeb60a53b219`
- all five canonical MCP names present; zero active old-wire matches in owned request/response/mapping files
- all 27 public Python files carry the exact notice with shebang-aware placement
- local no-auth sanitized MCP call and dedup/fanout integration passed in the private source review; an authenticated sanitized live call confirmed the hosted contract
- no secrets, private paths, runtime captures, `.egg-info`, or symlinks
- `publicationPerformed=false`
- `git diff --check` passes

This PR updates the public repository only. It does not submit a marketplace listing or modify production services.