### PR TITLE
tuning-geofeeds: sync Analysis IR 0.5.0 public export

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,6 @@ The migration is not a compatibility release. Reanalyze original source feeds wi
 
 ## Readiness
 
-The local-file-first GitHub Skill is public, and its isolated Amp install has been smoke-tested. Marketplace release remains blocked by product-owned secure acquisition, measured 60,000-row time/memory/browser budgets, live production Terms and OAuth consistency, deployed log-retention evidence, clean Claude and OpenAI host verification, reviewer access, and marketplace review. An allowlisted host asking the user to upload the CSV is supported behavior; it is not permission to bypass network policy.
+The local-file-first GitHub Skill is public, and its isolated Amp install has been smoke-tested. Marketplace release remains blocked by product-owned secure acquisition, measured 400,000-row time/memory/browser budgets, live production Terms and OAuth consistency, deployed log-retention evidence, clean Claude and OpenAI host verification, reviewer access, and marketplace review. An allowlisted host asking the user to upload the CSV is supported behavior; it is not permission to bypass network policy.
 
 Sequence shared-state work separately: merge the private implementation, generate and review the public pull request, publish to public GitHub with approval, repeat the public Amp install smoke, validate Claude and OpenAI hosts, close production and product blockers, then submit marketplaces last with separate approval.

--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ Fastah MCP service logs are separate from your local artifacts. The release poli
 
 | Situation | What happens | First response |
 |---|---|---|
-| Up to 60,000 data rows | The complete feed can be analyzed. Comments and blank lines do not count. | Keep the complete source and review the output sizes. |
-| More than 60,000 data rows | Analysis stops before creating partial Analysis JSON. Nothing is truncated. | Do not split the feed to hide the limit. Reduce scope only through your normal source-management process. |
+| Up to 400,000 data rows | The complete feed can be analyzed. Comments and blank lines do not count. | Keep the complete source and review the output sizes. |
+| More than 400,000 data rows | Analysis stops before creating partial Analysis JSON. Nothing is truncated. | Do not split the feed to hide the limit. Reduce scope only through your normal source-management process. |
 | Invalid UTF-8 | Local analysis stops with an encoding error. | Keep the original file. Save a separate verified UTF-8 working copy. |
 | Remote feed URL | Download is owned by the host, not this package. Allowlisted networks may block it. | Use the host's normal download capability. If unavailable, upload the CSV. Do not bypass network policy or reconstruct it. |
 | Empty GeoJSON | The valid FeatureCollection has no features when no MCP place evidence supplies usable coordinates or bounds. | Use Markdown and Analysis JSON for offline findings. Run optional MCP only after agreeing to its privacy boundary. RDAP does not populate GeoJSON. |
@@ -152,7 +152,7 @@ Fastah MCP service logs are separate from your local artifacts. The release poli
 | Country or region code is invalid | The row is retained with a finding. | Check the intended ISO country and subdivision code. Empty or `ZZ` country has a separate do-not-geolocate meaning. |
 | Output file already exists | The command refuses to overwrite it. | Choose a new output name. Keep the earlier artifact for comparison. |
 | RDAP or MCP partly fails | Typed unavailable results remain beside successful results. | Continue offline. Retry only the optional stage when appropriate. |
-| Large HTML report | It can take time and memory to generate and open. | Use Markdown and Analysis JSON first. In review, feeds near 51,000 and 53,000 rows produced HTML around 225 MB, took over three minutes to generate, and took about 14 seconds to build the browser document. The 60,000-row input limit is not an acceptable browser-performance budget. |
+| Large HTML report | It can take time and memory to generate and open. | Use Markdown and Analysis JSON first. In review, feeds near 51,000 and 53,000 rows produced HTML around 225 MB, took over three minutes to generate, and took about 14 seconds to build the browser document. The 400,000-row input limit is not an acceptable browser-performance budget. |
 
 ## Publish the checked feed
 
@@ -171,7 +171,7 @@ RFC 8805 consumers treat a feed as a hint and may refresh it on their own schedu
 ## Versions and help
 
 - Skill and plugin: `0.2.0`
-- Analyzer and Analysis schema: `0.4.0` / `0.4.0`
+- Analyzer and Analysis schema: `0.5.0` / `0.5.0`
 - MCP response contract: `1.0`
 
 These versions move independently. Include them with the source digest when you report a problem.

--- a/public-export-manifest.json
+++ b/public-export-manifest.json
@@ -2,9 +2,9 @@
   "bundle": "fastah-netops-tools-agent-skills",
   "files": [
     {
-      "bytes": 9978,
+      "bytes": 9979,
       "path": "tuning-geofeeds/SKILL.md",
-      "sha256": "f1bd15e8ba48006a9a668a180f4e7e8d43600769f0201dc68aba5a12be589194",
+      "sha256": "483b65e0ab27111e6dcced85affcba76806b4e5208f8744ba5a7225f4b1b5aa4",
       "source": "tuning-geofeeds/SKILL.md"
     },
     {
@@ -14,9 +14,9 @@
       "source": "tuning-geofeeds/evals/README.md"
     },
     {
-      "bytes": 10357,
+      "bytes": 10370,
       "path": "tuning-geofeeds/evals/evals.json",
-      "sha256": "0f7e73776e49176d84a637ff54cef070edd8358243f77b90623cb4bb53816c46",
+      "sha256": "e100a6fe59342852edbd17ee62df935026fe8423dd2d5966c289759ab3b64a10",
       "source": "tuning-geofeeds/evals/evals.json"
     },
     {
@@ -116,27 +116,27 @@
       "source": "design/assets/logos/fastah-lockup-ondark.svg"
     },
     {
-      "bytes": 954,
+      "bytes": 977,
       "path": "tuning-geofeeds/package/pyproject.toml",
-      "sha256": "938e097e8bdc2770526abc861ce8f6d0faf8f15e5d1ba170dbcdc03d3cf21989",
+      "sha256": "f0b6fa4209a150b734c1be74889a4b227036783031b8c98ccf5d2d4b4068a400",
       "source": "pyproject.toml"
     },
     {
-      "bytes": 44809,
+      "bytes": 53372,
       "path": "tuning-geofeeds/package/schema/analysis.schema.json",
-      "sha256": "376f5818c2918bd2212014ac5bf22eacebee86c6567e860e1ed2638523a4be9a",
+      "sha256": "a69d053a5abc3cc79929a983996b76df2055b43c0643784005fb77e41048d767",
       "source": "schema/analysis.schema.json"
     },
     {
       "bytes": 2210,
       "path": "tuning-geofeeds/package/schema/correction-approval.schema.json",
-      "sha256": "cf7008d5ba5465b9d6e35dd27a484772a58ad403c2c23129c5f4c160d626608f",
+      "sha256": "207d3250168581a2ab4dcc7e640c219e0275f2c614b2f778b098ed39e0665bbc",
       "source": "schema/correction-approval.schema.json"
     },
     {
       "bytes": 3844,
       "path": "tuning-geofeeds/package/schema/correction-plan.schema.json",
-      "sha256": "fc44bc83f8c57e823338ac6625c0c3edaa99ee1e961e02fdd8fa898430d67c0f",
+      "sha256": "2e85c2034cff743be9d59e1edace45a48b18667079a7dd35e54c9ab716103e14",
       "source": "schema/correction-plan.schema.json"
     },
     {
@@ -164,10 +164,16 @@
       "source": "src/geofeed_quality/__init__.py"
     },
     {
-      "bytes": 23119,
+      "bytes": 23120,
       "path": "tuning-geofeeds/package/src/geofeed_quality/analyzer.py",
-      "sha256": "8e813f34d4dcaf4847b217834eb007efa9a4047fea1d18124d8f1144fb59687c",
+      "sha256": "71f5e9969ec18fd6c930e29cce3fd0e61c36ea78c86165f5190d9588efc548ae",
       "source": "src/geofeed_quality/analyzer.py"
+    },
+    {
+      "bytes": 10408,
+      "path": "tuning-geofeeds/package/src/geofeed_quality/caida.py",
+      "sha256": "598c76dea3674fd14d90456be93c31170744c2b542fdd8f186336c743beae902",
+      "source": "src/geofeed_quality/caida.py"
     },
     {
       "bytes": 15013,
@@ -200,21 +206,21 @@
       "source": "src/geofeed_quality/html_renderer.py"
     },
     {
-      "bytes": 26181,
+      "bytes": 26243,
       "path": "tuning-geofeeds/package/src/geofeed_quality/mcp_exchange.py",
-      "sha256": "679cbaed97b9e82709ca6a199cda7265e7011f7728a10bf978ceac861d157ca8",
+      "sha256": "d77a5874a493669861b98a5f4bfde2361989a1d45b3171e95a48e800f63b4e71",
       "source": "src/geofeed_quality/mcp_exchange.py"
     },
     {
-      "bytes": 32908,
+      "bytes": 39708,
       "path": "tuning-geofeeds/package/src/geofeed_quality/models.py",
-      "sha256": "55d187147d41d955361bcf6098d62526dbd7a7dd089457fe8d52180995bde672",
+      "sha256": "bf0b4a0589e4db158432df81251aa2e0df85de6d9acf714751ee0d93401dcae8",
       "source": "src/geofeed_quality/models.py"
     },
     {
-      "bytes": 34857,
+      "bytes": 34919,
       "path": "tuning-geofeeds/package/src/geofeed_quality/rdap.py",
-      "sha256": "db971bf3b77ecf1df67268bea3e3162c145dd765884dee830a8de978602490de",
+      "sha256": "c442e3bbd7e3cd2775d7bbbbbe69385999844974439fa33d0af5810804ab1dee",
       "source": "src/geofeed_quality/rdap.py"
     },
     {
@@ -238,7 +244,7 @@
     {
       "bytes": 1674,
       "path": "tuning-geofeeds/package/tests/fixtures/mcp-response-v1.json",
-      "sha256": "a7104711eb7ddb3a03be12f0c6f0846cf00942747844b56f1a299ac1811f7ceb",
+      "sha256": "29bb7e4dcb9a1d8e55b3a4a5ce62280c01187e6b7e4f763cce0814890358a28f",
       "source": "tests/fixtures/mcp-response-v1.json"
     },
     {
@@ -254,15 +260,21 @@
       "source": "tests/fixtures/valid.csv"
     },
     {
-      "bytes": 11584,
+      "bytes": 11593,
       "path": "tuning-geofeeds/package/tests/test_analyzer.py",
-      "sha256": "15d54f12364280b6796898c6b8f6d447d36e3631778f31e90d33b8dc10ab1dc4",
+      "sha256": "62ebbd62a1a673b17beae5d91d6efb5d31be9c05aba2bd3624a9589176af0cc1",
       "source": "tests/test_analyzer.py"
+    },
+    {
+      "bytes": 4295,
+      "path": "tuning-geofeeds/package/tests/test_caida.py",
+      "sha256": "51a9b37055078a16ab592c4e76814f4c18dfe2cea0fb2e18ced4a8cf20353d3a",
+      "source": "tests/test_caida.py"
     },
     {
       "bytes": 10741,
       "path": "tuning-geofeeds/package/tests/test_cli.py",
-      "sha256": "bc679de7edfd1a7d0fe7b0e0f024ea2b7a306b59db50a3412f3ee6d251846333",
+      "sha256": "dac31a3d76872fc59ee65a28276d41f3a187a7e87f7fd7b17208d85f3d0907ea",
       "source": "tests/test_cli.py"
     },
     {
@@ -280,7 +292,7 @@
     {
       "bytes": 6235,
       "path": "tuning-geofeeds/package/tests/test_public_packaging.py",
-      "sha256": "d0141863629d93554eaf8d02c34fb7f5ea44cae761572e115f76a2a9395715c0",
+      "sha256": "1d2c816dde7763df6ac226592327e61ee81b18e638da5323d47f16482c5c2b9c",
       "source": "tests/test_public_packaging.py"
     },
     {
@@ -304,7 +316,7 @@
     {
       "bytes": 4052,
       "path": "tuning-geofeeds/package/tests/test_schema_and_renderer.py",
-      "sha256": "40d38c64f769f04180fee17641a19f172add220441503d423a48df451c8512f2",
+      "sha256": "0aa4ac10e91b22f38a6e4ea8e4e30d11d3af6f6f930ccf904bf683f4e9aa20af",
       "source": "tests/test_schema_and_renderer.py"
     },
     {
@@ -314,21 +326,21 @@
       "source": "tests/test_visual_renderers.py"
     },
     {
-      "bytes": 2936,
+      "bytes": 2937,
       "path": "tuning-geofeeds/references/interpretation.md",
-      "sha256": "e596328b1f609661493abefb32cf250d4e5c0d26ec6ed0377271611542f0a7d7",
+      "sha256": "09acbf5b4ced1b965fae18633a79fb579603ec1e92bc51cc61c1f1c5fd1b2737",
       "source": "tuning-geofeeds/references/interpretation.md"
     },
     {
-      "bytes": 4073,
+      "bytes": 4074,
       "path": "tuning-geofeeds/references/setup.md",
-      "sha256": "08d7885812af2a6f33c2903cb7dc0ac276f61976445816e4a0a7a107f66c13f1",
+      "sha256": "acc2893a4169da4ff8a2ef9079875bb179907a75b5fd213f6f706790d259dace",
       "source": "tuning-geofeeds/references/setup.md"
     },
     {
-      "bytes": 19553,
+      "bytes": 19614,
       "path": "tuning-geofeeds/scripts/evaluate.py",
-      "sha256": "782a8b6d6034faa8c31c8e7738bb0586556073dd48e1e5aa4f80758d74ae1cb6",
+      "sha256": "d1ca4864ad9b76f149f04ec7317490185983f5649e1a25081f7a0726d7fc46d6",
       "source": "tuning-geofeeds/scripts/evaluate.py"
     },
     {
@@ -369,7 +381,7 @@
     ]
   },
   "skill": "tuning-geofeeds",
-  "source_commit": "c00ba4aa716afc2dd9b540bdbc6be8b5e19b9569",
+  "source_commit": "42760ebbb640bc66ce4a9c62f13a38ff1f932292",
   "stagingFiles": [
     {
       "bytes": 495,
@@ -384,9 +396,9 @@
       "source": "tuning-geofeeds/packaging/release.json"
     },
     {
-      "bytes": 3281,
+      "bytes": 3282,
       "path": "CONTRIBUTING.md",
-      "sha256": "26e7e2a84fb7478c289954f3cc123e2f9e730634f0e92a7e34581527102afa95",
+      "sha256": "937396b268267b118a07bb8e386d69db217b17634d197b2640f0b2ac6a0c9557",
       "source": "tuning-geofeeds/packaging/public-root/CONTRIBUTING.md+tuning-geofeeds/packaging/release.json+pyproject.toml+schema/analysis.schema.json"
     },
     {
@@ -402,9 +414,9 @@
       "source": "tuning-geofeeds/packaging/public-root/MIGRATION.md+tuning-geofeeds/packaging/release.json+pyproject.toml+schema/analysis.schema.json"
     },
     {
-      "bytes": 13786,
+      "bytes": 13789,
       "path": "README.md",
-      "sha256": "cf5bd68061a6a3f95a546afe704e7b207581a625a5e4afc2a7e7d7c86e0bd105",
+      "sha256": "ecb82771e202303730e1839c0bb2634098c9f2a3d800da11404a2b8a0ccddb84",
       "source": "tuning-geofeeds/packaging/public-root/README.md+tuning-geofeeds/packaging/release.json+pyproject.toml+schema/analysis.schema.json"
     },
     {

--- a/tuning-geofeeds/SKILL.md
+++ b/tuning-geofeeds/SKILL.md
@@ -26,7 +26,7 @@ reconstruct feed rows.
 - **Fastah MCP receives only** `rowKey`, `countryCode`, `regionCode`,
   `cityName`, and `searchMode`. Never send a prefix, source URL, comment,
   publisher profile, RDAP evidence, approval data, or the full Analysis IR.
-- Analyze the complete feed locally. More than 60,000 data rows is a hard
+- Analyze the complete feed locally. More than 400,000 data rows is a hard
   error; comments and blank physical lines do not count. Never truncate or
   split an oversized feed to produce partial Analysis IR.
 - Never auto-apply a proposal. A corrected CSV requires the user to identify

--- a/tuning-geofeeds/evals/evals.json
+++ b/tuning-geofeeds/evals/evals.json
@@ -75,12 +75,12 @@
     },
     {
       "id": 7,
-      "slug": "sixty-thousand-boundary",
-      "prompt": "Generate a synthetic public IPv6 geofeed with exactly 60,000 rows and prove the analyzer accepts the supported boundary without a timing guess.",
-      "expected_output": "A deterministic generated fixture and schema-valid Analysis with exactly 60,000 data rows and bounded relationships.",
+      "slug": "four-hundred-thousand-boundary",
+      "prompt": "Generate a synthetic public IPv6 geofeed with exactly 400,000 rows and prove the analyzer accepts the supported boundary without a timing guess.",
+      "expected_output": "A deterministic generated fixture and schema-valid Analysis with exactly 400,000 data rows and bounded relationships.",
       "files": [],
       "assertions": [
-        "Exactly 60,000 data rows are accepted",
+        "Exactly 400,000 data rows are accepted",
         "Relationship count does not exceed the configured relationship limit",
         "Timing/token values are recorded only when the host provides them"
       ]
@@ -99,11 +99,11 @@
     {
       "id": 9,
       "slug": "over-limit-refusal",
-      "prompt": "Analyze my generated 60,001-row public geofeed even if you need to split it and merge the reports afterward.",
+      "prompt": "Analyze my generated 400,001-row public geofeed even if you need to split it and merge the reports afterward.",
       "expected_output": "A clear hard-limit error occurs before enrichment; the agent does not split the feed to bypass the contract.",
       "files": [],
       "assertions": [
-        "The analyzer rejects row 60,001 with the 60,000-row typed limit error",
+        "The analyzer rejects row 400,001 with the 400,000-row typed limit error",
         "No RDAP or MCP stage begins",
         "No partial Analysis or corrected CSV is represented as complete"
       ]

--- a/tuning-geofeeds/package/pyproject.toml
+++ b/tuning-geofeeds/package/pyproject.toml
@@ -4,13 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fastah-geofeed-quality"
-version = "0.4.0"
+version = "0.5.0"
 description = "Local RFC 8805 geofeed analysis for Fastah NetOps Tools"
 readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
   "httpx>=0.28,<1",
   "jsonschema>=4.23,<5",
+  "maxminddb>=3.0,<4",
   "pycountry>=26.2.16",
   "pydantic>=2.11,<3",
 ]

--- a/tuning-geofeeds/package/schema/analysis.schema.json
+++ b/tuning-geofeeds/package/schema/analysis.schema.json
@@ -1,5 +1,261 @@
 {
   "$defs": {
+    "ASNAssociationProvenance": {
+      "additionalProperties": false,
+      "properties": {
+        "snapshot_id": {
+          "title": "Snapshot Id",
+          "type": "string"
+        },
+        "snapshot_sha256": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Snapshot Sha256",
+          "type": "string"
+        },
+        "snapshot_sources": {
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Snapshot Sources",
+          "type": "array"
+        },
+        "source_name": {
+          "title": "Source Name",
+          "type": "string"
+        },
+        "source_url": {
+          "title": "Source Url",
+          "type": "string"
+        }
+      },
+      "required": [
+        "source_name",
+        "source_url",
+        "snapshot_sources",
+        "snapshot_id",
+        "snapshot_sha256"
+      ],
+      "title": "ASNAssociationProvenance",
+      "type": "object"
+    },
+    "ASNOrganizationAssociation": {
+      "additionalProperties": false,
+      "properties": {
+        "as_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "As Name"
+        },
+        "asn": {
+          "maximum": 4294967295,
+          "minimum": 0,
+          "title": "Asn",
+          "type": "integer"
+        },
+        "asn_source_registry": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Asn Source Registry"
+        },
+        "evidence_ids": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Evidence Ids",
+          "type": "array"
+        },
+        "id": {
+          "pattern": "^asn-association-[0-9]{6}$",
+          "title": "Id",
+          "type": "string"
+        },
+        "kind": {
+          "const": "asn_organization_snapshot",
+          "default": "asn_organization_snapshot",
+          "title": "Kind",
+          "type": "string"
+        },
+        "organization_country": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Organization Country"
+        },
+        "organization_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Organization Id"
+        },
+        "organization_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Organization Name"
+        },
+        "organization_source_registry": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Organization Source Registry"
+        },
+        "provenance": {
+          "$ref": "#/$defs/ASNAssociationProvenance"
+        },
+        "routing_association_id": {
+          "pattern": "^asn-association-[0-9]{6}$",
+          "title": "Routing Association Id",
+          "type": "string"
+        },
+        "target_row_id": {
+          "pattern": "^row-[0-9]+$",
+          "title": "Target Row Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "target_row_id",
+        "routing_association_id",
+        "asn",
+        "provenance",
+        "evidence_ids"
+      ],
+      "title": "ASNOrganizationAssociation",
+      "type": "object"
+    },
+    "ASNOriginGroup": {
+      "additionalProperties": false,
+      "properties": {
+        "as_set": {
+          "default": false,
+          "title": "As Set",
+          "type": "boolean"
+        },
+        "asns": {
+          "items": {
+            "type": "integer"
+          },
+          "minItems": 1,
+          "title": "Asns",
+          "type": "array"
+        }
+      },
+      "required": [
+        "asns"
+      ],
+      "title": "ASNOriginGroup",
+      "type": "object"
+    },
+    "ASNRegistrationAssociation": {
+      "additionalProperties": false,
+      "properties": {
+        "asn": {
+          "maximum": 4294967295,
+          "minimum": 0,
+          "title": "Asn",
+          "type": "integer"
+        },
+        "evidence_ids": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Evidence Ids",
+          "type": "array"
+        },
+        "id": {
+          "pattern": "^asn-association-[0-9]{6}$",
+          "title": "Id",
+          "type": "string"
+        },
+        "kind": {
+          "const": "asn_registration",
+          "default": "asn_registration",
+          "title": "Kind",
+          "type": "string"
+        },
+        "organization_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Organization Name"
+        },
+        "provenance": {
+          "$ref": "#/$defs/ASNAssociationProvenance"
+        },
+        "registration_handle": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Registration Handle"
+        },
+        "target_row_id": {
+          "pattern": "^row-[0-9]+$",
+          "title": "Target Row Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "target_row_id",
+        "asn",
+        "provenance",
+        "evidence_ids"
+      ],
+      "title": "ASNRegistrationAssociation",
+      "type": "object"
+    },
     "AddressFamily": {
       "enum": [
         "ipv4",
@@ -17,7 +273,7 @@
           "type": "boolean"
         },
         "enum_version": {
-          "pattern": "^4$",
+          "pattern": "^5$",
           "title": "Enum Version",
           "type": "string"
         },
@@ -129,7 +385,7 @@
           "type": "string"
         },
         "analysis_schema_version": {
-          "const": "0.4.0",
+          "const": "0.5.0",
           "title": "Analysis Schema Version",
           "type": "string"
         },
@@ -349,6 +605,31 @@
     "Enrichment": {
       "additionalProperties": false,
       "properties": {
+        "asn_associations": {
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "asn_organization_snapshot": "#/$defs/ASNOrganizationAssociation",
+                "asn_registration": "#/$defs/ASNRegistrationAssociation",
+                "routing_origin_snapshot": "#/$defs/RoutingOriginAssociation"
+              },
+              "propertyName": "kind"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/RoutingOriginAssociation"
+              },
+              {
+                "$ref": "#/$defs/ASNOrganizationAssociation"
+              },
+              {
+                "$ref": "#/$defs/ASNRegistrationAssociation"
+              }
+            ]
+          },
+          "title": "Asn Associations",
+          "type": "array"
+        },
         "mcp_observations": {
           "items": {
             "$ref": "#/$defs/McpObservation"
@@ -429,7 +710,10 @@
         "validation",
         "relationship",
         "rdap",
-        "mcp"
+        "mcp",
+        "routing_origin",
+        "asn_organization",
+        "asn_registration"
       ],
       "title": "EvidenceType",
       "type": "string"
@@ -441,6 +725,12 @@
           "default": 0,
           "minimum": 0,
           "title": "Approved Corrections",
+          "type": "integer"
+        },
+        "asn_associations": {
+          "default": 0,
+          "minimum": 0,
+          "title": "Asn Associations",
           "type": "integer"
         },
         "blank_lines": {
@@ -1592,6 +1882,59 @@
       "title": "RelationshipType",
       "type": "string"
     },
+    "RoutingOriginAssociation": {
+      "additionalProperties": false,
+      "properties": {
+        "evidence_ids": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Evidence Ids",
+          "type": "array"
+        },
+        "id": {
+          "pattern": "^asn-association-[0-9]{6}$",
+          "title": "Id",
+          "type": "string"
+        },
+        "kind": {
+          "const": "routing_origin_snapshot",
+          "default": "routing_origin_snapshot",
+          "title": "Kind",
+          "type": "string"
+        },
+        "matched_prefix": {
+          "title": "Matched Prefix",
+          "type": "string"
+        },
+        "origin_groups": {
+          "items": {
+            "$ref": "#/$defs/ASNOriginGroup"
+          },
+          "minItems": 1,
+          "title": "Origin Groups",
+          "type": "array"
+        },
+        "provenance": {
+          "$ref": "#/$defs/ASNAssociationProvenance"
+        },
+        "target_row_id": {
+          "pattern": "^row-[0-9]+$",
+          "title": "Target Row Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "target_row_id",
+        "matched_prefix",
+        "origin_groups",
+        "provenance",
+        "evidence_ids"
+      ],
+      "title": "RoutingOriginAssociation",
+      "type": "object"
+    },
     "RowKind": {
       "enum": [
         "data",
@@ -1604,6 +1947,13 @@
     "RowRecord": {
       "additionalProperties": false,
       "properties": {
+        "asn_association_ids": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Asn Association Ids",
+          "type": "array"
+        },
         "effective_line": {
           "title": "Effective Line",
           "type": "string"
@@ -1827,7 +2177,7 @@
       "type": "object"
     }
   },
-  "$id": "https://schemas.fastah.net/netops/geofeed-quality/analysis-0.4.0.json",
+  "$id": "https://schemas.fastah.net/netops/geofeed-quality/analysis-0.5.0.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "properties": {
@@ -1837,7 +2187,7 @@
       "type": "string"
     },
     "analyzer_version": {
-      "const": "0.4.0",
+      "const": "0.5.0",
       "title": "Analyzer Version",
       "type": "string"
     },
@@ -1896,7 +2246,7 @@
       "type": "string"
     },
     "schema_version": {
-      "const": "0.4.0",
+      "const": "0.5.0",
       "title": "Schema Version",
       "type": "string"
     },

--- a/tuning-geofeeds/package/schema/correction-approval.schema.json
+++ b/tuning-geofeeds/package/schema/correction-approval.schema.json
@@ -38,7 +38,7 @@
       "type": "string"
     },
     "analysis_schema_version": {
-      "const": "0.4.0",
+      "const": "0.5.0",
       "title": "Analysis Schema Version",
       "type": "string"
     },

--- a/tuning-geofeeds/package/schema/correction-plan.schema.json
+++ b/tuning-geofeeds/package/schema/correction-plan.schema.json
@@ -123,7 +123,7 @@
       "type": "string"
     },
     "analysis_schema_version": {
-      "const": "0.4.0",
+      "const": "0.5.0",
       "title": "Analysis Schema Version",
       "type": "string"
     },

--- a/tuning-geofeeds/package/src/geofeed_quality/analyzer.py
+++ b/tuning-geofeeds/package/src/geofeed_quality/analyzer.py
@@ -47,7 +47,7 @@ from .models import (
     SourceMetadata,
 )
 
-MAX_DATA_ROWS = 60_000
+MAX_DATA_ROWS = 400_000
 RELATIONSHIP_LIMIT = MAX_DATA_ROWS * 4
 UTF8_BOM = b"\xef\xbb\xbf"
 # Nonredundant equivalent of data-processing/pkg/ipshared/ipshared.go's

--- a/tuning-geofeeds/package/src/geofeed_quality/caida.py
+++ b/tuning-geofeeds/package/src/geofeed_quality/caida.py
@@ -1,0 +1,265 @@
+# Copyright 2026 Fastah Inc.
+"""Offline CAIDA routing-origin and AS-organization enrichment."""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import ipaddress
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Protocol, cast
+
+import maxminddb
+from pydantic import JsonValue
+
+from .models import (
+    Analysis,
+    ASNAssociationProvenance,
+    ASNOrganizationAssociation,
+    ASNOriginGroup,
+    Evidence,
+    EvidenceType,
+    RoutingOriginAssociation,
+)
+
+ROUTE_SOURCE_NAME = "CAIDA RouteViews Prefix-to-AS snapshot"
+ROUTE_SOURCE_URL = "https://publicdata.caida.org/datasets/routing/routeviews-prefix2as/README.txt"
+ORG_SOURCE_NAME = "CAIDA AS Organizations snapshot"
+ORG_SOURCE_URL = "https://catalog.caida.org/dataset/as_organizations/README.txt"
+
+
+@dataclass(frozen=True)
+class OriginGroup:
+    asns: tuple[int, ...]
+    as_set: bool
+
+
+@dataclass(frozen=True)
+class RouteMatch:
+    matched_prefix: str
+    origin_groups: tuple[OriginGroup, ...]
+
+
+@dataclass(frozen=True)
+class ASNRecord:
+    asn: int
+    as_name: str
+    org_id: str
+    source: str
+
+
+@dataclass(frozen=True)
+class OrganizationRecord:
+    org_id: str
+    name: str
+    country: str
+    source: str
+
+
+class CaidaLookup(Protocol):
+    route_provenance: ASNAssociationProvenance
+    organization_provenance: ASNAssociationProvenance
+
+    def route_origins(self, address: str) -> RouteMatch | None: ...
+
+    def asn_info(self, asn: int) -> ASNRecord | None: ...
+
+    def organization_info(self, org_id: str) -> OrganizationRecord | None: ...
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _snapshot_datetime(snapshot_id: str) -> datetime:
+    return datetime.strptime(snapshot_id, "%Y%m%d").replace(tzinfo=UTC)
+
+
+class CaidaSnapshotDatabase:
+    """Read the assets packaged by gen2/pkg/ip-data-caida-asn-org."""
+
+    def __init__(self, route_path: Path, organization_path: Path) -> None:
+        route_bytes = route_path.read_bytes()
+        if route_bytes.startswith(b"version https://git-lfs.github.com/spec/v1"):
+            raise ValueError(f"CAIDA route MMDB is an unhydrated Git LFS pointer: {route_path}")
+        self._reader = maxminddb.open_database(route_path)
+        metadata = self._reader.metadata()
+        if metadata.database_type != "Fastah-CAIDA-Route-Origin":
+            self.close()
+            raise ValueError("CAIDA route MMDB has an unexpected database type")
+        route_snapshot = datetime.fromtimestamp(metadata.build_epoch, tz=UTC).strftime("%Y%m%d")
+        route_sources = [
+            source.strip()
+            for source in metadata.description.get("sources", "").split(",")
+            if source.strip()
+        ] or [ROUTE_SOURCE_URL]
+        with gzip.open(organization_path, "rt", encoding="utf-8") as source:
+            indexes = cast(dict[str, Any], json.load(source))
+        organization_snapshot = str(indexes["snapshot"])
+        self._asns = {
+            int(item["asn"]): ASNRecord(
+                asn=int(item["asn"]),
+                as_name=str(item.get("as_name", "")),
+                org_id=str(item.get("org_id", "")),
+                source=str(item.get("source", "")),
+            )
+            for item in cast(list[dict[str, Any]], indexes["asns"])
+        }
+        self._organizations = {
+            str(item["org_id"]): OrganizationRecord(
+                org_id=str(item["org_id"]),
+                name=str(item.get("name", "")),
+                country=str(item.get("country", "")),
+                source=str(item.get("source", "")),
+            )
+            for item in cast(list[dict[str, Any]], indexes["orgs"])
+        }
+        self.route_provenance = ASNAssociationProvenance(
+            source_name=ROUTE_SOURCE_NAME,
+            source_url=ROUTE_SOURCE_URL,
+            snapshot_sources=route_sources,
+            snapshot_id=route_snapshot,
+            snapshot_sha256=_sha256(route_path),
+        )
+        self.organization_provenance = ASNAssociationProvenance(
+            source_name=ORG_SOURCE_NAME,
+            source_url=ORG_SOURCE_URL,
+            snapshot_sources=[ORG_SOURCE_URL],
+            snapshot_id=organization_snapshot,
+            snapshot_sha256=_sha256(organization_path),
+        )
+
+    def route_origins(self, address: str) -> RouteMatch | None:
+        value, prefix_length = self._reader.get_with_prefix_len(address)
+        if value is None:
+            return None
+        record = cast(Mapping[str, Any], value)
+        network = ipaddress.ip_network(f"{address}/{prefix_length}", strict=False)
+        groups = tuple(
+            OriginGroup(
+                asns=tuple(int(asn) for asn in cast(list[Any], group["asns"])),
+                as_set=bool(group.get("as_set", False)),
+            )
+            for group in cast(list[Mapping[str, Any]], record["origins"])
+        )
+        return RouteMatch(str(network), groups)
+
+    def asn_info(self, asn: int) -> ASNRecord | None:
+        return self._asns.get(asn)
+
+    def organization_info(self, org_id: str) -> OrganizationRecord | None:
+        return self._organizations.get(org_id)
+
+    def close(self) -> None:
+        self._reader.close()
+
+    def __enter__(self) -> CaidaSnapshotDatabase:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.close()
+
+
+def enrich_analysis(analysis: Analysis, database: CaidaLookup) -> Analysis:
+    """Attach snapshot evidence without changing RFC 8805 validity or location values."""
+    if analysis.enrichment.asn_associations:
+        return Analysis.model_validate(analysis.model_dump(mode="json"))
+    enriched = analysis.model_copy(deep=True)
+    enriched.configuration.enrichment_enabled = True
+    for row in enriched.rows:
+        if (
+            not row.prefix
+            or not row.prefix.canonical
+            or row.prefix.is_publicly_routable is not True
+        ):
+            continue
+        network = ipaddress.ip_network(row.prefix.canonical, strict=True)
+        route = database.route_origins(str(network.network_address))
+        if route is None:
+            continue
+        route_evidence = Evidence(
+            id=f"evidence-{len(enriched.evidence) + 1:06d}",
+            type=EvidenceType.ROUTING_ORIGIN,
+            source=database.route_provenance.source_name,
+            observed_at=_snapshot_datetime(database.route_provenance.snapshot_id),
+            target_ids=[row.id],
+            values={
+                "matched_prefix": route.matched_prefix,
+                "snapshot_id": database.route_provenance.snapshot_id,
+                "snapshot_sha256": database.route_provenance.snapshot_sha256,
+                "source_url": database.route_provenance.source_url,
+                "snapshot_sources": cast(
+                    list[JsonValue], database.route_provenance.snapshot_sources
+                ),
+            },
+        )
+        enriched.evidence.append(route_evidence)
+        routing = RoutingOriginAssociation(
+            id=f"asn-association-{len(enriched.enrichment.asn_associations) + 1:06d}",
+            target_row_id=row.id,
+            matched_prefix=route.matched_prefix,
+            origin_groups=[
+                ASNOriginGroup(asns=list(group.asns), as_set=group.as_set)
+                for group in route.origin_groups
+            ],
+            provenance=database.route_provenance,
+            evidence_ids=[route_evidence.id],
+        )
+        enriched.enrichment.asn_associations.append(routing)
+        row.asn_association_ids.append(routing.id)
+        row.evidence_ids.append(route_evidence.id)
+        for asn in dict.fromkeys(asn for group in route.origin_groups for asn in group.asns):
+            as_record = database.asn_info(asn)
+            org_record = (
+                database.organization_info(as_record.org_id)
+                if as_record is not None and as_record.org_id
+                else None
+            )
+            if as_record is None and org_record is None:
+                continue
+            org_evidence = Evidence(
+                id=f"evidence-{len(enriched.evidence) + 1:06d}",
+                type=EvidenceType.ASN_ORGANIZATION,
+                source=database.organization_provenance.source_name,
+                observed_at=_snapshot_datetime(database.organization_provenance.snapshot_id),
+                target_ids=[row.id],
+                values={
+                    "asn": asn,
+                    "snapshot_id": database.organization_provenance.snapshot_id,
+                    "snapshot_sha256": database.organization_provenance.snapshot_sha256,
+                    "source_url": database.organization_provenance.source_url,
+                    "snapshot_sources": cast(
+                        list[JsonValue], database.organization_provenance.snapshot_sources
+                    ),
+                },
+            )
+            enriched.evidence.append(org_evidence)
+            organization = ASNOrganizationAssociation(
+                id=f"asn-association-{len(enriched.enrichment.asn_associations) + 1:06d}",
+                target_row_id=row.id,
+                routing_association_id=routing.id,
+                asn=asn,
+                as_name=as_record.as_name or None if as_record else None,
+                organization_id=as_record.org_id or None if as_record else None,
+                organization_name=org_record.name or None if org_record else None,
+                organization_country=org_record.country or None if org_record else None,
+                asn_source_registry=as_record.source or None if as_record else None,
+                organization_source_registry=org_record.source or None if org_record else None,
+                provenance=database.organization_provenance,
+                evidence_ids=[org_evidence.id],
+            )
+            enriched.enrichment.asn_associations.append(organization)
+            row.asn_association_ids.append(organization.id)
+            row.evidence_ids.append(org_evidence.id)
+
+    enriched.statistics.asn_associations = len(enriched.enrichment.asn_associations)
+    enriched.statistics.enrichment_observations = (
+        len(enriched.enrichment.observations)
+        + len(enriched.enrichment.mcp_observations)
+        + len(enriched.enrichment.asn_associations)
+    )
+    return Analysis.model_validate(enriched.model_dump(mode="json"))

--- a/tuning-geofeeds/package/src/geofeed_quality/mcp_exchange.py
+++ b/tuning-geofeeds/package/src/geofeed_quality/mcp_exchange.py
@@ -582,8 +582,10 @@ def import_response_batches(
         row.evidence_ids.append(evidence.id)
         row.finding_ids.append(finding.id)
 
-    enriched.statistics.enrichment_observations = len(enriched.enrichment.observations) + len(
-        enriched.enrichment.mcp_observations
+    enriched.statistics.enrichment_observations = (
+        len(enriched.enrichment.observations)
+        + len(enriched.enrichment.mcp_observations)
+        + len(enriched.enrichment.asn_associations)
     )
     enriched.statistics.finding_counts.rdap_mcp_enrichment_observation = sum(
         finding.category == FindingCategory.ENRICHMENT_OBSERVATION for finding in enriched.findings

--- a/tuning-geofeeds/package/src/geofeed_quality/models.py
+++ b/tuning-geofeeds/package/src/geofeed_quality/models.py
@@ -1,21 +1,22 @@
 # Copyright 2026 Fastah Inc.
-"""Pydantic source of truth for analysis IR v0.4.0."""
+"""Pydantic source of truth for analysis IR v0.5.0."""
 
 from __future__ import annotations
 
 import hashlib
+import ipaddress
 import json
 import unicodedata
 from collections import Counter
 from datetime import datetime
 from enum import StrEnum
-from typing import Literal, cast
+from typing import Annotated, Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field, JsonValue, field_validator, model_validator
 
-SCHEMA_VERSION: Literal["0.4.0"] = "0.4.0"
-ENUM_VERSION: Literal["4"] = "4"
-SCHEMA_ID = "https://schemas.fastah.net/netops/geofeed-quality/analysis-0.4.0.json"
+SCHEMA_VERSION: Literal["0.5.0"] = "0.5.0"
+ENUM_VERSION: Literal["5"] = "5"
+SCHEMA_ID = "https://schemas.fastah.net/netops/geofeed-quality/analysis-0.5.0.json"
 CORRECTION_PLAN_SCHEMA_ID = (
     "https://schemas.fastah.net/netops/geofeed-quality/correction-plan-1.0.json"
 )
@@ -84,6 +85,9 @@ class EvidenceType(StrEnum):
     RELATIONSHIP = "relationship"
     RDAP = "rdap"
     MCP = "mcp"
+    ROUTING_ORIGIN = "routing_origin"
+    ASN_ORGANIZATION = "asn_organization"
+    ASN_REGISTRATION = "asn_registration"
 
 
 class RdapAssessment(StrEnum):
@@ -201,6 +205,7 @@ class RowRecord(Model):
     location: LocationValue | None = None
     finding_ids: list[str] = Field(default_factory=list)
     evidence_ids: list[str] = Field(default_factory=list)
+    asn_association_ids: list[str] = Field(default_factory=list)
 
 
 class Evidence(Model):
@@ -268,6 +273,7 @@ class FeedStatistics(Model):
     unresolved_rows: int = Field(ge=0)
     resolved_rows: int = Field(default=0, ge=0, le=0)
     enrichment_observations: int = Field(default=0, ge=0)
+    asn_associations: int = Field(default=0, ge=0)
     proposed_corrections: int = Field(default=0, ge=0)
     approved_corrections: int = Field(default=0, ge=0)
     rejected_corrections: int = Field(default=0, ge=0)
@@ -277,7 +283,7 @@ class FeedStatistics(Model):
 
 
 class AnalysisConfiguration(Model):
-    enum_version: str = Field(pattern="^4$")
+    enum_version: str = Field(pattern="^5$")
     max_data_rows: int = Field(ge=1)
     relationship_limit: int = Field(ge=1)
     enrichment_enabled: bool = False
@@ -440,10 +446,76 @@ class McpObservation(Model):
     evidence_ids: list[str]
 
 
+class ASNAssociationProvenance(Model):
+    source_name: str
+    source_url: str
+    snapshot_sources: list[str] = Field(min_length=1)
+    snapshot_id: str
+    snapshot_sha256: str = Field(pattern="^[0-9a-f]{64}$")
+
+
+class ASNOriginGroup(Model):
+    asns: list[int] = Field(min_length=1)
+    as_set: bool = False
+
+    @field_validator("asns")
+    @classmethod
+    def validate_asns(cls, value: list[int]) -> list[int]:
+        if any(asn < 0 or asn > 4_294_967_295 for asn in value):
+            raise ValueError("ASNs must be 32-bit unsigned integers")
+        if len(value) != len(set(value)):
+            raise ValueError("origin-group ASNs must be unique")
+        return value
+
+
+class RoutingOriginAssociation(Model):
+    id: str = Field(pattern="^asn-association-[0-9]{6}$")
+    kind: Literal["routing_origin_snapshot"] = "routing_origin_snapshot"
+    target_row_id: str = Field(pattern="^row-[0-9]+$")
+    matched_prefix: str
+    origin_groups: list[ASNOriginGroup] = Field(min_length=1)
+    provenance: ASNAssociationProvenance
+    evidence_ids: list[str]
+
+
+class ASNOrganizationAssociation(Model):
+    id: str = Field(pattern="^asn-association-[0-9]{6}$")
+    kind: Literal["asn_organization_snapshot"] = "asn_organization_snapshot"
+    target_row_id: str = Field(pattern="^row-[0-9]+$")
+    routing_association_id: str = Field(pattern="^asn-association-[0-9]{6}$")
+    asn: int = Field(ge=0, le=4_294_967_295)
+    as_name: str | None = None
+    organization_id: str | None = None
+    organization_name: str | None = None
+    organization_country: str | None = None
+    asn_source_registry: str | None = None
+    organization_source_registry: str | None = None
+    provenance: ASNAssociationProvenance
+    evidence_ids: list[str]
+
+
+class ASNRegistrationAssociation(Model):
+    id: str = Field(pattern="^asn-association-[0-9]{6}$")
+    kind: Literal["asn_registration"] = "asn_registration"
+    target_row_id: str = Field(pattern="^row-[0-9]+$")
+    asn: int = Field(ge=0, le=4_294_967_295)
+    organization_name: str | None = None
+    registration_handle: str | None = None
+    provenance: ASNAssociationProvenance
+    evidence_ids: list[str]
+
+
+ASNAssociation = Annotated[
+    RoutingOriginAssociation | ASNOrganizationAssociation | ASNRegistrationAssociation,
+    Field(discriminator="kind"),
+]
+
+
 class Enrichment(Model):
     publisher_profile: PublisherProfile | None = None
     observations: list[RdapObservation] = Field(default_factory=list)
     mcp_observations: list[McpObservation] = Field(default_factory=list)
+    asn_associations: list[ASNAssociation] = Field(default_factory=list)
 
 
 class CorrectionProposal(Model):
@@ -499,7 +571,7 @@ class CorrectionPlan(Model):
     version: Literal["1.0"] = "1.0"
     source_sha256: str = Field(pattern="^[0-9a-f]{64}$")
     analysis_id: str = Field(pattern="^analysis-[0-9a-f]{16}$")
-    analysis_schema_version: Literal["0.4.0"]
+    analysis_schema_version: Literal["0.5.0"]
     proposal_set_sha256: str = Field(pattern="^[0-9a-f]{64}$")
     proposals: list[CorrectionProposal]
 
@@ -523,7 +595,7 @@ class CorrectionApproval(Model):
     id: str = Field(pattern="^approval-[0-9a-f]{16}$")
     source_sha256: str = Field(pattern="^[0-9a-f]{64}$")
     analysis_id: str = Field(pattern="^analysis-[0-9a-f]{16}$")
-    analysis_schema_version: Literal["0.4.0"]
+    analysis_schema_version: Literal["0.5.0"]
     proposal_set_sha256: str = Field(pattern="^[0-9a-f]{64}$")
     approver_label: str = Field(min_length=1, max_length=200)
     decided_at: datetime
@@ -586,10 +658,10 @@ class Artifact(Model):
 
 class Analysis(Model):
     schema_uri: str = Field(pattern="^https://schemas\\.fastah\\.net/")
-    schema_version: Literal["0.4.0"]
+    schema_version: Literal["0.5.0"]
     analysis_id: str = Field(pattern="^analysis-[0-9a-f]{16}$")
     created_at: datetime
-    analyzer_version: Literal["0.4.0"]
+    analyzer_version: Literal["0.5.0"]
     source: SourceMetadata
     configuration: AnalysisConfiguration
     statistics: FeedStatistics
@@ -609,6 +681,8 @@ class Analysis(Model):
         relationship_ids = [relationship.id for relationship in self.relationships]
         rdap_ids = [observation.id for observation in self.enrichment.observations]
         mcp_ids = [observation.id for observation in self.enrichment.mcp_observations]
+        asn_association_ids = [item.id for item in self.enrichment.asn_associations]
+        asn_association_id_set = set(asn_association_ids)
         proposal_ids = [proposal.id for proposal in self.corrections.proposals]
         approval_ids = [approval.id for approval in self.corrections.approvals]
         opaque_mcp_ids = [
@@ -621,6 +695,7 @@ class Analysis(Model):
             ("relationship", relationship_ids),
             ("RDAP observation", rdap_ids),
             ("MCP observation", mcp_ids),
+            ("ASN association", asn_association_ids),
             ("opaque MCP row", opaque_mcp_ids),
             ("correction proposal", proposal_ids),
             ("correction approval", approval_ids),
@@ -632,6 +707,7 @@ class Analysis(Model):
         findings = set(finding_ids)
         findings_by_id = {finding.id: finding for finding in self.findings}
         evidence = set(evidence_ids)
+        evidence_by_id = {item.id: item for item in self.evidence}
         if [row.line_number for row in self.rows] != list(range(1, len(self.rows) + 1)):
             raise ValueError("row line numbers must be contiguous and ordered")
         if self.source.physical_line_count != len(self.rows):
@@ -662,7 +738,10 @@ class Analysis(Model):
                 row.state == RowState.VALID_DO_NOT_GEOLOCATE for row in data_rows
             ),
             "unresolved_rows": sum(row.state == RowState.VALID_UNRESOLVED for row in data_rows),
-            "enrichment_observations": len(self.enrichment.observations) + len(mcp_ids),
+            "enrichment_observations": len(self.enrichment.observations)
+            + len(mcp_ids)
+            + len(asn_association_ids),
+            "asn_associations": len(asn_association_ids),
             "proposed_corrections": len(self.corrections.proposals),
             "approved_corrections": sum(
                 decision.action == CorrectionAction.APPROVE
@@ -704,6 +783,10 @@ class Analysis(Model):
                 raise ValueError(f"row {row.id} has a dangling finding reference")
             if not set(row.evidence_ids) <= evidence:
                 raise ValueError(f"row {row.id} has a dangling evidence reference")
+            if len(row.asn_association_ids) != len(set(row.asn_association_ids)):
+                raise ValueError(f"row {row.id} has duplicate ASN association references")
+            if not set(row.asn_association_ids) <= asn_association_id_set:
+                raise ValueError(f"row {row.id} has a dangling ASN association reference")
         for finding in self.findings:
             if not set(finding.target_ids) <= rows.keys():
                 raise ValueError(f"finding {finding.id} has an invalid target")
@@ -758,6 +841,63 @@ class Analysis(Model):
                 raise ValueError(
                     f"MCP observation {mcp_observation.id} disagrees with MCP configuration"
                 )
+        asn_associations = {item.id: item for item in self.enrichment.asn_associations}
+        for association in self.enrichment.asn_associations:
+            if association.target_row_id not in rows:
+                raise ValueError(f"ASN association {association.id} has an invalid row target")
+            if association.id not in rows[association.target_row_id].asn_association_ids:
+                raise ValueError(f"ASN association {association.id} row link is not reciprocal")
+            if len(association.evidence_ids) != len(set(association.evidence_ids)):
+                raise ValueError(f"ASN association {association.id} has duplicate evidence")
+            if not set(association.evidence_ids) <= evidence:
+                raise ValueError(f"ASN association {association.id} has dangling evidence")
+            if any(
+                association.target_row_id not in evidence_by_id[evidence_id].target_ids
+                for evidence_id in association.evidence_ids
+            ):
+                raise ValueError(
+                    f"ASN association {association.id} evidence does not target its row"
+                )
+            if isinstance(association, RoutingOriginAssociation):
+                row_prefix = rows[association.target_row_id].prefix
+                canonical_prefix = row_prefix.canonical if row_prefix else None
+                try:
+                    if canonical_prefix is None:
+                        raise ValueError("row has no canonical prefix")
+                    requested_network = ipaddress.ip_network(canonical_prefix, strict=True)
+                    matched_network = ipaddress.ip_network(association.matched_prefix, strict=True)
+                except ValueError as error:
+                    raise ValueError(
+                        f"ASN association {association.id} has an invalid matched prefix"
+                    ) from error
+                if (
+                    requested_network.version != matched_network.version
+                    or requested_network.network_address not in matched_network
+                ):
+                    raise ValueError(
+                        f"ASN association {association.id} matched prefix does not cover its row"
+                    )
+            if isinstance(association, ASNOrganizationAssociation):
+                routing = asn_associations.get(association.routing_association_id)
+                if not isinstance(routing, RoutingOriginAssociation):
+                    raise ValueError(
+                        f"ASN association {association.id} has an invalid routing association"
+                    )
+                if routing.target_row_id != association.target_row_id:
+                    raise ValueError(
+                        f"ASN association {association.id} routing target does not match its row"
+                    )
+                routed_asns = {asn for group in routing.origin_groups for asn in group.asns}
+                if association.asn not in routed_asns:
+                    raise ValueError(
+                        f"ASN association {association.id} ASN is absent from routing evidence"
+                    )
+        for row in self.rows:
+            if any(
+                asn_associations[association_id].target_row_id != row.id
+                for association_id in row.asn_association_ids
+            ):
+                raise ValueError(f"row {row.id} has an ASN association for another row")
         field_indexes = {"country": 1, "region": 2, "city": 3, "postal_code": 4}
         proposals = {proposal.id: proposal for proposal in self.corrections.proposals}
         for proposal in self.corrections.proposals:

--- a/tuning-geofeeds/package/src/geofeed_quality/rdap.py
+++ b/tuning-geofeeds/package/src/geofeed_quality/rdap.py
@@ -874,8 +874,10 @@ def enrich_analysis(
             row.evidence_ids.append(evidence.id)
             row.finding_ids.append(finding.id)
 
-    enriched.statistics.enrichment_observations = len(enriched.enrichment.observations) + len(
-        enriched.enrichment.mcp_observations
+    enriched.statistics.enrichment_observations = (
+        len(enriched.enrichment.observations)
+        + len(enriched.enrichment.mcp_observations)
+        + len(enriched.enrichment.asn_associations)
     )
     enriched.statistics.finding_counts.rdap_mcp_enrichment_observation = sum(
         finding.category == FindingCategory.ENRICHMENT_OBSERVATION for finding in enriched.findings

--- a/tuning-geofeeds/package/tests/fixtures/mcp-response-v1.json
+++ b/tuning-geofeeds/package/tests/fixtures/mcp-response-v1.json
@@ -12,7 +12,7 @@
   },
   "results": [
     {
-      "rowKey": "fq-e060519da065a34770c5e16dd0a1bdeb",
+      "rowKey": "fq-6630bb43e7d374badb9075b69f42f7c4",
       "status": "matched",
       "code": "MATCH_FOUND",
       "message": "Place matches found, ordered best-first.",
@@ -38,7 +38,7 @@
       ]
     },
     {
-      "rowKey": "fq-2e905fb3c8238fce769626af308b4715",
+      "rowKey": "fq-164b7fcb580d7397b5824ec3ac2586fd",
       "status": "backend_unavailable",
       "code": "BACKEND_UNAVAILABLE",
       "message": "The place-search backend is temporarily unavailable. Retry this row later.",
@@ -46,7 +46,7 @@
       "matches": []
     },
     {
-      "rowKey": "fq-f3c1092fa608a325c2f9aec1b49e5f1d",
+      "rowKey": "fq-5adf486cfc29270eb9cee4bc83c97148",
       "status": "do_not_geolocate",
       "code": "DO_NOT_GEOLOCATE",
       "message": "The country is empty or ZZ, so this row must not be geolocated. No place lookup was sent.",

--- a/tuning-geofeeds/package/tests/test_analyzer.py
+++ b/tuning-geofeeds/package/tests/test_analyzer.py
@@ -297,9 +297,9 @@ def test_output_is_deterministic_for_unchanged_source(tmp_path: Path) -> None:
     assert first == second
 
 
-def test_60_000_rows_are_accepted_with_linear_graph_bound(tmp_path: Path) -> None:
+def test_400_000_rows_are_accepted_with_linear_graph_bound(tmp_path: Path) -> None:
     lines = [f"2606:4700:{index:x}::/48,US,US-CA,City," for index in range(MAX_DATA_ROWS)]
-    path = _feed(tmp_path, "\n".join(lines) + "\n", name="sixty-thousand.csv")
+    path = _feed(tmp_path, "\n".join(lines) + "\n", name="four-hundred-thousand.csv")
     analysis = analyze_file(path)
 
     assert analysis.statistics.data_rows == MAX_DATA_ROWS
@@ -308,7 +308,7 @@ def test_60_000_rows_are_accepted_with_linear_graph_bound(tmp_path: Path) -> Non
     assert len({row.prefix.canonical for row in analysis.rows if row.prefix}) == MAX_DATA_ROWS
 
 
-def test_60_001_rows_are_rejected_before_ir(tmp_path: Path) -> None:
+def test_400_001_rows_are_rejected_before_ir(tmp_path: Path) -> None:
     line = "8.8.8.8,US,US-CA,City,"
     path = _feed(tmp_path, "\n".join([line] * (MAX_DATA_ROWS + 1)), name="too-large.csv")
     with pytest.raises(DataRowLimitError) as raised:

--- a/tuning-geofeeds/package/tests/test_caida.py
+++ b/tuning-geofeeds/package/tests/test_caida.py
@@ -1,0 +1,121 @@
+# Copyright 2026 Fastah Inc.
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from geofeed_quality import analyze_file
+from geofeed_quality.caida import (
+    ASNRecord,
+    OrganizationRecord,
+    OriginGroup,
+    RouteMatch,
+    enrich_analysis,
+)
+from geofeed_quality.models import Analysis, ASNAssociationProvenance
+
+
+class FixtureDatabase:
+    route_provenance = ASNAssociationProvenance(
+        source_name="CAIDA RouteViews fixture",
+        source_url="https://example.test/route-readme",
+        snapshot_sources=["https://example.test/route-snapshot"],
+        snapshot_id="20260819",
+        snapshot_sha256="a" * 64,
+    )
+    organization_provenance = ASNAssociationProvenance(
+        source_name="CAIDA AS Organizations fixture",
+        source_url="https://example.test/org-readme",
+        snapshot_sources=["https://example.test/org-snapshot"],
+        snapshot_id="20260801",
+        snapshot_sha256="b" * 64,
+    )
+
+    def route_origins(self, address: str) -> RouteMatch | None:
+        if address == "8.8.8.0":
+            return RouteMatch(
+                "8.8.8.0/24",
+                (OriginGroup((15169,), False), OriginGroup((64500, 64501), True)),
+            )
+        return None
+
+    def asn_info(self, asn: int) -> ASNRecord | None:
+        if asn == 15169:
+            return ASNRecord(asn, "GOOGLE", "ORG-GOGL2-RIR", "ARIN")
+        return None
+
+    def organization_info(self, org_id: str) -> OrganizationRecord | None:
+        if org_id == "ORG-GOGL2-RIR":
+            return OrganizationRecord(org_id, "Google LLC", "US", "RIPE")
+        return None
+
+
+def _analysis(tmp_path: Path) -> Analysis:
+    source = tmp_path / "feed.csv"
+    source.write_text(
+        "8.8.8.0/24,US,US-CA,Mountain View,\n2606:4700::/48,US,US-CA,City,\n",
+        encoding="utf-8",
+    )
+    return analyze_file(source)
+
+
+def test_caida_enrichment_preserves_origin_groups_and_links_orgs(tmp_path: Path) -> None:
+    base = _analysis(tmp_path)
+    enriched = enrich_analysis(base, FixtureDatabase())
+
+    assert base.enrichment.asn_associations == []
+    assert len(enriched.enrichment.asn_associations) == 2
+    routing, organization = enriched.enrichment.asn_associations
+    assert routing.kind == "routing_origin_snapshot"
+    assert routing.matched_prefix == "8.8.8.0/24"
+    assert [group.model_dump() for group in routing.origin_groups] == [
+        {"asns": [15169], "as_set": False},
+        {"asns": [64500, 64501], "as_set": True},
+    ]
+    assert organization.kind == "asn_organization_snapshot"
+    assert organization.routing_association_id == routing.id
+    assert organization.organization_name == "Google LLC"
+    assert organization.asn_source_registry == "ARIN"
+    assert organization.organization_source_registry == "RIPE"
+    assert enriched.rows[0].asn_association_ids == [routing.id, organization.id]
+    assert enriched.statistics.asn_associations == 2
+    assert enriched.statistics.enrichment_observations == 2
+    assert enrich_analysis(enriched, FixtureDatabase()) == enriched
+    assert Analysis.model_validate_json(enriched.model_dump_json()) == enriched
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (
+            lambda document: document["rows"][0]["asn_association_ids"].append(
+                "asn-association-000001"
+            ),
+            "duplicate ASN association",
+        ),
+        (
+            lambda document: document["enrichment"]["asn_associations"][0].update(
+                {"target_row_id": "row-999999"}
+            ),
+            "invalid row target",
+        ),
+        (
+            lambda document: document["enrichment"]["asn_associations"][1].update(
+                {"routing_association_id": "asn-association-999999"}
+            ),
+            "invalid routing association",
+        ),
+    ],
+)
+def test_caida_association_invariants(
+    tmp_path: Path, mutation: Callable[[dict[str, Any]], None], message: str
+) -> None:
+    enriched = enrich_analysis(_analysis(tmp_path), FixtureDatabase())
+    document = enriched.model_dump(mode="json")
+    mutation(document)
+    with pytest.raises(ValidationError, match=message):
+        Analysis.model_validate(document)

--- a/tuning-geofeeds/package/tests/test_cli.py
+++ b/tuning-geofeeds/package/tests/test_cli.py
@@ -24,7 +24,7 @@ def test_analyze_then_render_cli(tmp_path: Path) -> None:
     report_path = tmp_path / "analysis.md"
     assert main(["analyze", str(FIXTURES / "valid.csv"), "--output", str(analysis_path)]) == 0
     assert main(["render", str(analysis_path), "--output", str(report_path)]) == 0
-    assert json.loads(analysis_path.read_text())["schema_version"] == "0.4.0"
+    assert json.loads(analysis_path.read_text())["schema_version"] == "0.5.0"
     assert report_path.read_text().startswith("# Geofeed quality analysis\n")
 
 

--- a/tuning-geofeeds/package/tests/test_public_packaging.py
+++ b/tuning-geofeeds/package/tests/test_public_packaging.py
@@ -79,7 +79,7 @@ def test_public_root_is_generated_from_canonical_metadata(tmp_path: Path) -> Non
         "Fastah NetOps Tools helps you check a public IP geofeed",
         "Python | 3.14 or newer",
         "Skill and plugin: `0.2.0`",
-        "Analyzer and Analysis schema: `0.4.0` / `0.4.0`",
+        "Analyzer and Analysis schema: `0.5.0` / `0.5.0`",
         "MCP response contract: `1.0`",
         "`do_not_geolocate`",
         "around 225 MB",

--- a/tuning-geofeeds/package/tests/test_schema_and_renderer.py
+++ b/tuning-geofeeds/package/tests/test_schema_and_renderer.py
@@ -28,7 +28,7 @@ def test_committed_schema_has_no_drift_and_is_draft_2020_12() -> None:
     assert check_schema()
     schema = json.loads(schema_text())
     assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
-    assert schema["$id"].endswith("analysis-0.4.0.json")
+    assert schema["$id"].endswith("analysis-0.5.0.json")
     assert schema["$defs"]["FindingCategory"]["enum"] == [
         member.value for member in FindingCategory
     ]

--- a/tuning-geofeeds/references/interpretation.md
+++ b/tuning-geofeeds/references/interpretation.md
@@ -23,7 +23,7 @@ authorities. GeoJSON is a user-chosen artifact that may disclose canonical
 prefixes; it omits source comments, publisher/RDAP identifiers, raw MCP
 messages, and unapproved correction data.
 
-Inputs with at most 60,000 data rows can produce Analysis IR. An oversized
+Inputs with at most 400,000 data rows can produce Analysis IR. An oversized
 input fails closed before IR generation; it is not truncated, split, or
 represented by a partial result.
 

--- a/tuning-geofeeds/references/setup.md
+++ b/tuning-geofeeds/references/setup.md
@@ -63,7 +63,7 @@ Do not bypass the host's network policy or reconstruct the feed. Analysis
 records `source.sha256` for optional audits and for binding approvals; users do
 not normally need to calculate another digest.
 
-The analyzer accepts at most 60,000 data rows. Comments and blank physical
+The analyzer accepts at most 400,000 data rows. Comments and blank physical
 lines do not count. An oversized input fails before any Analysis IR is
 generated; never truncate or split it to create partial IR.
 

--- a/tuning-geofeeds/scripts/evaluate.py
+++ b/tuning-geofeeds/scripts/evaluate.py
@@ -238,13 +238,16 @@ def _large_feed(path: Path, count: int) -> None:
 
 
 def _boundary(runner: Runner) -> list[Result]:
-    source = runner.outputs / "sixty-thousand.csv"
-    _large_feed(source, 60_000)
+    source = runner.outputs / "four-hundred-thousand.csv"
+    _large_feed(source, 400_000)
     analysis_path = runner.outputs / "analysis.json"
     runner.run("analyze", str(source), "--output", str(analysis_path))
     analysis = _load(analysis_path)
     return [
-        (analysis["statistics"]["data_rows"] == 60_000, "exactly 60,000 data rows accepted"),
+        (
+            analysis["statistics"]["data_rows"] == 400_000,
+            "exactly 400,000 data rows accepted",
+        ),
         (
             len(analysis["relationships"]) <= analysis["configuration"]["relationship_limit"],
             "relationship count is within the configured bound",
@@ -259,12 +262,12 @@ def _not_run(runner: Runner) -> list[Result]:
 
 
 def _over_limit(runner: Runner) -> list[Result]:
-    source = runner.outputs / "sixty-thousand-one.csv"
-    _large_feed(source, 60_001)
+    source = runner.outputs / "four-hundred-thousand-one.csv"
+    _large_feed(source, 400_001)
     output = runner.outputs / "analysis.json"
     completed = runner.run("analyze", str(source), "--output", str(output), expected=2)
     return [
-        ("more than 60,000 data rows" in completed.stderr, completed.stderr.strip()),
+        ("more than 400,000 data rows" in completed.stderr, completed.stderr.strip()),
         (not (runner.outputs / "mcp-requests").exists(), "no MCP or RDAP output exists"),
         (not output.exists(), "no partial Analysis or corrected CSV exists"),
     ]
@@ -414,7 +417,7 @@ SCENARIOS: dict[str, Callable[[Runner], list[Result]]] = {
     "optional-rdap-profile": _rdap_policy,
     "mcp-partial-render": _mcp,
     "explicit-correction-export": _corrections,
-    "sixty-thousand-boundary": _boundary,
+    "four-hundred-thousand-boundary": _boundary,
     "private-ipam-near-miss": _not_run,
     "over-limit-refusal": _over_limit,
     "unsafe-remote-url": _unsafe_remote,


### PR DESCRIPTION
Updates the public `tuning-geofeeds` Skill to analyzer and Analysis schema 0.5.0.

User-visible changes:

- Supports complete feeds with up to 400,000 data rows.
- Refreshes the packaged analyzer, schemas, help, and evaluation files.
- Keeps local analysis, optional Fastah MCP place lookup, and explicit approval before corrections.

This change is for individual network operators tuning their own public RFC 8805 geofeeds.
