### PR TITLE
Clarify Fastah MCP schema discovery

### DIFF
--- a/tuning-geofeeds/SKILL.md
+++ b/tuning-geofeeds/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tuning-geofeeds
-description: "Analyzes and tunes public IP RFC 8805 geofeed CSVs for network operators, preserving evidence while producing JSON, Markdown, HTML, GeoJSON, and explicitly approved corrected feeds. Use for public prefix geolocation quality, duplicate or carved-prefix review, optional RDAP consistency evidence, or Fastah place-search enrichment; do not use for private/internal IPAM or generic CSV work."
+description: 'Analyzes and tunes public IP RFC 8805 geofeed CSVs for network operators, preserving evidence while producing JSON, Markdown, HTML, GeoJSON, and explicitly approved corrected feeds. Use for public prefix geolocation quality, duplicate or carved-prefix review, optional RDAP consistency evidence, or Fastah place-search enrichment; do not use for private/internal IPAM or generic CSV work.'
 license: Apache-2.0
 compatibility: "Requires Python 3.14+. Runs locally by default; network access is optional and limited to managed public-HTTPS acquisition, direct authoritative RIR RDAP, and host-mediated Fastah MCP."
 metadata:
@@ -34,6 +34,10 @@ reconstruct feed rows.
 - RDAP evidence can be `consistent`, `conflicting`, `unverified`, or
   `unavailable`; it never proves legal ownership. MCP matches are advisory.
   Rank, population weight, and radius are not confidence.
+- `package/schema/mcp-place-search-request.schema.json` and
+  `package/schema/mcp-place-search-response.schema.json` are frozen local
+  adapter/exchange contract v1.0 schemas. They validate the local export/import
+  envelope and audit captures; they are not the live Fastah MCP tool schemas.
 - Do not write parser, validator, schema, renderer, or correction scripts.
   Invoke `scripts/geofeed_cli.py`; the typed models and committed schemas are
   the source of truth.
@@ -118,11 +122,22 @@ analysis usable; report `unavailable` rather than guessing.
 
 ### 4. Optionally add host-mediated Fastah MCP evidence
 
-Ask the host to discover the Fastah MCP tool `rfc8805-row-place-search`, its
-current closed schema, and its advertised positive batch limit. If the host
-asks the user to sign in, use the host's normal OAuth flow. Never ask the user
-to paste a password, token, or other credential. Do not implement OAuth/MCP
-transport. Export batches using that exact discovered limit:
+If the user opts in, have the host complete its normal OAuth flow, then use
+`tools/list` (including all pages) to rediscover the current Fastah MCP tool
+definitions before use. This workflow uses `rfc8805-row-place-search`; Fastah
+may offer other tools, so do not treat it as the only valid Fastah MCP tool.
+Read that tool's current `inputSchema`, `outputSchema`, and advertised positive
+batch limit. Rediscover after a `notifications/tools/list_changed` notification
+or before a later enrichment run; do not substitute the committed local adapter
+schemas for discovery. Never ask the user to paste a password, token, or other
+credential. Do not implement OAuth/MCP transport.
+
+Use MCP only when the discovered `rfc8805-row-place-search` definition has an
+`outputSchema` and supports the five allowlisted request fields plus the
+row-correlation semantics needed by the local adapter. If it lacks an
+`outputSchema`, cannot satisfy those checks, or MCP is unavailable, explain
+that enrichment was skipped and continue with the local analysis. Export
+batches using the discovered limit:
 
 ```bash
 "$PYTHON" "$RUN" mcp-export "$CURRENT_IR" \
@@ -130,8 +145,8 @@ transport. Export batches using that exact discovered limit:
   --output-dir "$WORK/mcp-requests"
 ```
 
-Have the host invoke only `rfc8805-row-place-search` once per batch and save
-each structured response in order under `WORK`. Inspect every outbound JSON
+Have the host invoke `rfc8805-row-place-search` once per batch and save each
+validated structured response in order under `WORK`. Inspect every outbound JSON
 object first: it must contain only `rows`, and every row must contain only the
 five allowlisted fields above. Export deterministically groups only exact,
 byte-identical `(countryCode, regionCode, cityName, searchMode)` tuples in

--- a/tuning-geofeeds/package/README.md
+++ b/tuning-geofeeds/package/README.md
@@ -33,3 +33,15 @@ reconstruct the feed. Analysis records `source.sha256` for optional audits and
 for binding approvals to the analyzed file.
 
 The skill workflow and safety boundaries are in [`../SKILL.md`](../SKILL.md).
+
+## MCP schema boundary
+
+`schema/mcp-place-search-request.schema.json` and
+`schema/mcp-place-search-response.schema.json` are frozen local
+adapter/exchange contract v1.0 schemas. They validate the analyzer's local
+export/import envelope and retained audit captures; they do not define the live
+Fastah MCP server contract. After normal host OAuth, discover the current tool
+definition with `tools/list` before enrichment. This workflow uses
+`rfc8805-row-place-search` when its discovered `inputSchema` and `outputSchema`
+support the local privacy-preserving adapter. If it has no `outputSchema` or is
+incompatible, skip MCP enrichment and continue with local analysis.

--- a/tuning-geofeeds/package/schema/mcp-place-search-request.schema.json
+++ b/tuning-geofeeds/package/schema/mcp-place-search-request.schema.json
@@ -52,6 +52,7 @@
   "$id": "https://schemas.fastah.net/netops/geofeed-quality/mcp-place-search-request-1.0.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
+  "description": "Frozen local adapter/exchange contract v1.0 request envelope. It is not the live Fastah MCP tool inputSchema; discover that via tools/list.",
   "properties": {
     "rows": {
       "items": {

--- a/tuning-geofeeds/package/schema/mcp-place-search-response.schema.json
+++ b/tuning-geofeeds/package/schema/mcp-place-search-response.schema.json
@@ -240,6 +240,7 @@
   "$id": "https://schemas.fastah.net/netops/geofeed-quality/mcp-place-search-response-1.0.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
+  "description": "Frozen local adapter/exchange contract v1.0 response envelope. It is not the live Fastah MCP tool outputSchema; discover that via tools/list.",
   "properties": {
     "batchLimit": {
       "minimum": 1,

--- a/tuning-geofeeds/package/src/geofeed_quality/mcp_exchange.py
+++ b/tuning-geofeeds/package/src/geofeed_quality/mcp_exchange.py
@@ -1,5 +1,5 @@
 # Copyright 2026 Fastah Inc.
-"""Host-mediated Fastah MCP request export and response import.
+"""Host-mediated Fastah MCP local adapter/exchange request export and response import.
 
 This module intentionally has no MCP transport, OAuth, or credential handling.
 """
@@ -65,6 +65,18 @@ class McpRequestRow(WireModel):
 
 
 class McpRequestBatch(WireModel):
+    """Frozen local adapter/exchange v1.0 request envelope, not a live MCP tool schema."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+        json_schema_extra={
+            "description": (
+                "Frozen local adapter/exchange contract v1.0 request envelope. "
+                "It is not the live Fastah MCP tool inputSchema; discover that via tools/list."
+            )
+        },
+    )
     rows: list[McpRequestRow] = Field(min_length=1)
 
     @model_validator(mode="after")
@@ -222,6 +234,18 @@ class McpResponseSummary(WireModel):
 
 
 class McpResponseBatch(WireModel):
+    """Frozen local adapter/exchange v1.0 response envelope, not a live MCP tool schema."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+        json_schema_extra={
+            "description": (
+                "Frozen local adapter/exchange contract v1.0 response envelope. "
+                "It is not the live Fastah MCP tool outputSchema; discover that via tools/list."
+            )
+        },
+    )
     contract_version: Literal["1.0"] = Field(alias="contractVersion")
     batch_limit: int = Field(alias="batchLimit", ge=1)
     summary: McpResponseSummary


### PR DESCRIPTION
## Summary
- document committed MCP request/response schemas as frozen local adapter/exchange contracts
- require post-auth `tools/list` rediscovery before Fastah place-search enrichment
- skip optional enrichment when the discovered output schema is unavailable or incompatible

## Verification
- `python3 -m json.tool` for both committed schemas
- `git diff --check`

The full analyzer runtime requires Python 3.14+; the orb system interpreter is Python 3.11.